### PR TITLE
feat(streaming): allow lambda image function to return streamed response

### DIFF
--- a/packages/open-next/src/adapters/streaming.ts
+++ b/packages/open-next/src/adapters/streaming.ts
@@ -1,0 +1,53 @@
+import { ResponseStream } from "../types.js";
+
+/*
+This is a AWS's implementation of Lambda Streaming.
+It allows us to return larger responses than the 6MB limit of Lambda.
+
+Credits to:
+- @adamelmore (https://github.com/serverless-stack/sst/pull/3165)
+- @astuyve (https://github.com/astuyve/lambda-stream)
+
+*/
+export function streamSuccess(
+    result: any, // NextJS Image optimization result.
+    responseStream: ResponseStream
+  ) {
+    responseStream = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: 200,
+      headers: {
+        Vary: "Accept",
+        "Cache-Control": `public,max-age=${result.maxAge},immutable`,
+        "Content-Type": result.contentType,
+        'x-response-type': 'stream',
+      }
+    });
+
+    responseStream.write(result.buffer)
+    responseStream.end()
+  }
+
+export function streamError(
+    statusCode: number,
+    error: string | Error | any,
+    responseStream: ResponseStream
+  ) {
+    console.error(error);
+
+    responseStream = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode,
+      headers: {
+        Vary: "Accept",
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache',
+        'x-response-type': 'stream',
+      }
+    });
+
+    responseStream.write(JSON.stringify({
+      message: 'Error has occured while processing image',
+      body: error?.message || error?.toString() || error,
+    }));
+
+    responseStream.end();
+  }

--- a/packages/open-next/src/adapters/streaming.ts
+++ b/packages/open-next/src/adapters/streaming.ts
@@ -13,6 +13,7 @@ export function streamSuccess(
     result: any, // NextJS Image optimization result.
     responseStream: ResponseStream
   ) {
+    // Once headers are set via `HttpResponseStream`. We shall not call `responseStream.setContentType` as it messes up the stream.
     responseStream = awslambda.HttpResponseStream.from(responseStream, {
       statusCode: 200,
       headers: {

--- a/packages/open-next/src/types.d.ts
+++ b/packages/open-next/src/types.d.ts
@@ -1,0 +1,40 @@
+// @TODO: Add Credits to Astro SST team.
+
+import { APIGatewayProxyEventV2, Callback, Context } from "aws-lambda";
+import { Writable } from "node:stream";
+
+declare global {
+  const awslambda: {
+    streamifyResponse(handler: RequestHandler): RequestHandler;
+    HttpResponseStream: {
+      from(
+        underlyingStream: ResponseStream,
+        metadata: {
+          statusCode: number;
+          headers?: Record<string, string>;
+        }
+      ): ResponseStream;
+    };
+  };
+
+  interface CompressionStream {
+    readonly readable: ReadableStream;
+    readonly writable: WritableStream;
+  }
+  const CompressionStream: {
+    prototype: CompressionStream;
+    new (format: "gzip" | "deflate"): CompressionStream;
+  };
+}
+
+export interface ResponseStream extends Writable {
+  getBufferedData(): Buffer;
+  setContentType(contentType: string): void;
+}
+
+export type RequestHandler = (
+  event: APIGatewayProxyEventV2,
+  streamResponse: ResponseStream,
+  context?: Context,
+  callback?: Callback
+) => void | Promise<void>;


### PR DESCRIPTION
This PR reacts to AWS's streaming. See: https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/. It's a minimalistic implementation purely for Image handler which we can continue building upon with other handlers.

In order to make this work, we need to do following:
- `invokeMode: InvokeMode.RESPONSE_STREAM` to be added here: https://github.com/serverless-stack/sst/blob/0529f6291e925aa3809abc746429964dcfce433b/packages/sst/src/constructs/NextjsSite.ts#L415C8-L415C8

Related to: https://github.com/serverless-stack/open-next/issues/79


Previous implementation is kept, it might be reasonable to remove it if all is fine with this PR.