### PR TITLE
feat: use trustHostHeader to set req.url to host

### DIFF
--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -191,7 +191,7 @@ function setNextjsPrebundledReact(rawPath: string) {
 function createRequestHandler() {
   return new NextServer.default({
     hostname: "localhost",
-    port: 3000,
+    // port: IMPORTANT: DO NOT SET PORT so that request.url is set to actual host
     conf: {
       ...config,
       // Next.js compression should be disabled because of a bug in the bundled
@@ -201,6 +201,9 @@ function createRequestHandler() {
       // our own cache handler to store the cache on S3.
       experimental: {
         ...config.experimental,
+        // This uses the request.headers.host as the URL
+        // https://github.com/vercel/next.js/blob/canary/packages/next/src/server/next-server.ts#L1749-L1754
+        trustHostHeader: true,
         incrementalCacheHandlerPath: `${process.env.LAMBDA_TASK_ROOT}/cache.cjs`,
       },
     },


### PR DESCRIPTION
Currently, `request.url` (eg inside a .route file) will be `https://localhost:3000/api/hi`.

This PR sets `trustHostHeader: true` which sets `request.url` to the actual url of the app, eg: `https://example.com/api/hi`