### PR TITLE
feat: add support for multiple revalidation at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ To facilitate this:
 - The default cache handler is replaced with a custom cache handler by configuring the [`incrementalCacheHandlerPath`](https://nextjs.org/docs/app/api-reference/next-config-js/incrementalCacheHandlerPath) field in `next.config.js`.
 - The custom cache handler manages the cache files on S3, handling both reading and writing operations.
 - If the cache is stale, the `server-function` sends the stale response back to the user while sending a message to the revalidation queue to trigger background revalidation.
+- Since we're using FIFO queue, if we want to process more than one revalidation at a time, we need to have separate Message Group IDs. We generate a Message Group ID for each revalidation request based on the route path. This ensures that revalidation requests for the same route are processed only once. You can use `MAX_REVALIDATE_CONCURRENCY` environment variable to control the number of revalidation requests processed at a time. By default, it is set to 10.
 - The `revalidation-function` polls the message from the queue and makes a `HEAD` request to the route with the `x-prerender-revalidate` header.
 - The `server-function` receives the `HEAD` request and revalidates the cache.
 

--- a/examples/app-router/app/api/isr/route.ts
+++ b/examples/app-router/app/api/isr/route.ts
@@ -1,0 +1,27 @@
+import fs from "fs/promises";
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+
+// This endpoint simulates an on demand revalidation request
+export async function GET(request: NextRequest) {
+  const cwd = process.cwd();
+  const prerenderManifest = await fs.readFile(
+    path.join(cwd, ".next/prerender-manifest.json"),
+    "utf-8",
+  );
+  const manifest = JSON.parse(prerenderManifest);
+  const previewId = manifest.preview.previewModeId;
+
+  const result = await fetch(`https://${request.url}/isr`, {
+    headers: { "x-prerender-revalidate": previewId },
+    method: "HEAD",
+  });
+
+  return NextResponse.json({
+    status: 200,
+    body: {
+      result: result.ok,
+      cacheControl: result.headers.get("cache-control"),
+    },
+  });
+}

--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -113,11 +113,55 @@ export async function revalidateIfRequired(
         QueueUrl: REVALIDATION_QUEUE_URL,
         MessageDeduplicationId: hash(`${rawPath}-${headers.etag}`),
         MessageBody: JSON.stringify({ host, url: revalidateUrl }),
-        MessageGroupId: "revalidate",
+        MessageGroupId: generateMessageGroupId(rawPath),
       }),
     );
   } catch (e) {
     debug(`Failed to revalidate stale page ${rawPath}`);
     debug(e);
   }
+}
+
+// Since we're using a FIFO queue, every messageGroupId is treated sequentially
+// This could cause a backlog of messages in the queue if there is too much page to
+// revalidate at once. To avoid this, we generate a random messageGroupId for each
+// revalidation request.
+// We can't just use a random string because we need to ensure that the same rawPath
+// will always have the same messageGroupId.
+// https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript#answer-47593316
+function generateMessageGroupId(rawPath: string) {
+  let a = cyrb128(rawPath);
+  // We use mulberry32 to generate a random int between 0 and MAX_REVALIDATE_CONCURRENCY
+  var t = (a += 0x6d2b79f5);
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  const randomFloat = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  // This will generate a random int between 0 and MAX_REVALIDATE_CONCURRENCY
+  // This means that we could have 1000 revalidate request at the same time
+  const maxConcurrency = parseInt(
+    process.env.MAX_REVALIDATE_CONCURRENCY ?? "10",
+  );
+  const randomInt = Math.floor(randomFloat * maxConcurrency);
+  return `revalidate-${randomInt}`;
+}
+
+// Used to generate a hash int from a string
+function cyrb128(str: string) {
+  let h1 = 1779033703,
+    h2 = 3144134277,
+    h3 = 1013904242,
+    h4 = 2773480762;
+  for (let i = 0, k; i < str.length; i++) {
+    k = str.charCodeAt(i);
+    h1 = h2 ^ Math.imul(h1 ^ k, 597399067);
+    h2 = h3 ^ Math.imul(h2 ^ k, 2869860233);
+    h3 = h4 ^ Math.imul(h3 ^ k, 951274213);
+    h4 = h1 ^ Math.imul(h4 ^ k, 2716044179);
+  }
+  h1 = Math.imul(h3 ^ (h1 >>> 18), 597399067);
+  h2 = Math.imul(h4 ^ (h2 >>> 22), 2869860233);
+  h3 = Math.imul(h1 ^ (h3 >>> 17), 951274213);
+  h4 = Math.imul(h2 ^ (h4 >>> 19), 2716044179);
+  (h1 ^= h2 ^ h3 ^ h4), (h2 ^= h1), (h3 ^= h1), (h4 ^= h1);
+  return h1 >>> 0;
 }

--- a/packages/open-next/src/adapters/revalidate.ts
+++ b/packages/open-next/src/adapters/revalidate.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import type { SQSEvent } from "aws-lambda";
 
-import { debug } from "./logger.js";
+import { debug, error } from "./logger.js";
 
 const prerenderManifest = loadPrerenderManifest();
 
@@ -41,7 +41,10 @@ export const handler = async (event: SQSEvent) => {
         },
         (res) => resolve(res),
       );
-      req.on("error", (err) => reject(err));
+      req.on("error", (err) => {
+        error(`Error revalidating page`, { host, url });
+        reject(err);
+      });
       req.end();
     });
   }

--- a/packages/tests-e2e/tests/appRouter/isr.revalidate.test.ts
+++ b/packages/tests-e2e/tests/appRouter/isr.revalidate.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test("Test revalidate", async ({ request }) => {
+  const result = await request.get("/api/isr");
+
+  expect(result.status()).toEqual(200);
+  const body = await result.json();
+  expect(body.result).toEqual(true);
+  expect(body.cacheControl).toEqual(
+    "private, no-cache, no-store, max-age=0, must-revalidate",
+  );
+});


### PR DESCRIPTION
Right now there is an issue with ISR due to the way a SQS FIFO Queue works.
SQS FIFO queue process revalidation page only one at a time for each messageGroupId. For website with a lot of ISR routes, there might be a backlog that will build up with time.

In order to solve this, we set the MessageGroupId of each SQS request like `revalidate-RANDOM_INT`.
This random int also need to always be the same for every unique path.

You could now set an env variable `MAX_REVALIDATE_CONCURRENCY` on the server function to specify the max number of simultaneous revalidate that you want. By default this env variable is set to 10.
