### PR TITLE
Run e2e on main push

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,8 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  # Checks the latest Nextjs Version, if it's not been tested before, it will
+  # Continue to the next job where it does the actual Playwright tests
   check_next_version:
     runs-on: ubuntu-latest
 
@@ -59,9 +61,11 @@ jobs:
       previousNextVersion: ${{ steps.get_latest_version.outputs.LATEST_VERSION }}
       cacheKey: ${{ steps.cache-previous.outputs.cache-primary-key }}
 
+  # If the event is push (merged and pushed into main) or if 
+  # the latest Nextjs version hasn't been tested, run the Playwright tests
   e2e:
     needs: check_next_version
-    if: needs.check_next_version.outputs.skip != 'true'
+    if: github.event_name == 'push' || needs.check_next_version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:
 
@@ -115,9 +119,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      # Build all the packages
+      # Build only the open-next package + its monorepo dependencies
       - name: Build
-        run: pnpm run build
+        run: pnpm --filter open-next... run build
 
       # Deploy e2e stage
       - name: Deploy NextjsSite

--- a/examples/app-pages-router/next.config.js
+++ b/examples/app-pages-router/next.config.js
@@ -1,9 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   poweredByHeader: false,
-  output: "standalone",
   transpilePackages: ["@example/shared"],
-  outputFileTracing: "../sst",
   experimental: {
     serverActions: true,
   },

--- a/examples/app-router/next.config.js
+++ b/examples/app-router/next.config.js
@@ -1,9 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   poweredByHeader: false,
-  output: "standalone",
   transpilePackages: ["@example/shared"],
-  outputFileTracing: "../sst",
   experimental: {
     serverActions: true,
   },

--- a/examples/pages-router/next.config.js
+++ b/examples/pages-router/next.config.js
@@ -2,8 +2,6 @@
 const nextConfig = {
   transpilePackages: ["@example/shared"],
   reactStrictMode: true,
-  output: "standalone",
-  outputFileTracing: "../sst",
 };
 
 module.exports = nextConfig;

--- a/examples/pages-router/package.json
+++ b/examples/pages-router/package.json
@@ -11,7 +11,6 @@
      "clean": "rm -rf .turbo node_modules .next .open-next"
   },
   "dependencies": {
-    "@next/font": "13.4.16",
     "@example/shared": "workspace:*",
     "@types/node": "20.5.0",
     "@types/react": "18.2.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,6 @@ importers:
       '@example/shared':
         specifier: workspace:*
         version: link:../shared
-      '@next/font':
-        specifier: 13.4.16
-        version: 13.4.16
       '@types/node':
         specifier: 20.5.0
         version: 20.5.0
@@ -2670,10 +2667,6 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/font@13.4.16:
-    resolution: {integrity: sha512-1UciFHgwieMfDygileymqeYPEmIeZWIfgrsa2POZlRW+yAsDt0qy0InfFAYvXhNgALTI6ix3JU2XhcuzonhQLA==}
-    dev: false
-
   /@next/swc-darwin-arm64@13.4.12:
     resolution: {integrity: sha512-deUrbCXTMZ6ZhbOoloqecnUeNpUOupi8SE2tx4jPfNS9uyUR9zK4iXBvH65opVcA/9F5I/p8vDXSYbUlbmBjZg==}
     engines: {node: '>= 10'}
@@ -4186,8 +4179,8 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.10
-      caniuse-lite: 1.0.30001524
-      fraction.js: 4.3.2
+      caniuse-lite: 1.0.30001525
+      fraction.js: 4.3.4
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.4.27
@@ -4402,7 +4395,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001524
+      caniuse-lite: 1.0.30001525
       electron-to-chromium: 1.4.506
       node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.10)
@@ -4502,8 +4495,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite@1.0.30001524:
-    resolution: {integrity: sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==}
+  /caniuse-lite@1.0.30001525:
+    resolution: {integrity: sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==}
 
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
@@ -6213,8 +6206,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /fraction.js@4.3.2:
-    resolution: {integrity: sha512-9VLF466MqX1OUP7/d9r7/Vsvu6Hpp+taXBLmiR5x6mEYfT0BDkGVBt5TyA1aDu1WzIE1sF8F66evOFaz7iAEGQ==}
+  /fraction.js@4.3.4:
+    resolution: {integrity: sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==}
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -7992,7 +7985,7 @@ packages:
       '@next/env': 13.4.12
       '@swc/helpers': 0.5.1
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001524
+      caniuse-lite: 1.0.30001525
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
Removed the next.config.js output and tracing to see if that's necessary if we only build the `open-next` package.