### PR TITLE
Introduce a custom build-output-path and app-path argument for more flexible monorepo support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,26 @@ await build({
 });
 ```
 
+#### Custom app and build output paths
+
+OpenNext runs the `build` script from your current command folder by default. When running OpenNext from a monorepo with decentralised application and build output paths, you can specify a custom `appPath` and/or `buildOutputPath`. This will allow you to execute your command from the root of the monorepo.
+
+```bash
+# CLI
+open-next build --build-command "pnpm custom:build" --app-path "./apps/example-app" --build-output-path "./dist/apps/example-app"
+```
+
+```ts
+// JS
+import { build } from "open-next/build.js";
+
+await build({
+  buildCommand: "pnpm custom:build",
+  appPath: "./apps/example-app",
+  buildOutputPath: "./dist/apps/example-app"
+});
+```
+
 #### Minify server function
 
 Enabling this option will minimize all `.js` and `.json` files in the server function bundle using the [node-minify](https://github.com/srod/node-minify) library. This can reduce the size of the server function bundle by about 40%, depending on the size of your app.

--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -28,6 +28,16 @@ export function middleware(request: NextRequest) {
   );
   const responseHeaders = new Headers();
   responseHeaders.set("response-header", "response-header");
+
+  // Set the cache control header with custom swr
+  // For: isr.test.ts
+  if (path === "/isr") {
+    responseHeaders.set(
+      "cache-control",
+      "max-age=10, stale-while-revalidate=999",
+    );
+  }
+
   const r = NextResponse.next({
     headers: responseHeaders,
     request: {

--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -56,9 +56,9 @@ export function fixCacheHeaderForHtmlPages(
 
 export function fixSWRCacheHeader(headers: Record<string, string | undefined>) {
   // WORKAROUND: `NextServer` does not set correct SWR cache headers — https://github.com/serverless-stack/open-next#workaround-nextserver-does-not-set-correct-swr-cache-headers
-  if (headers["cache-control"]?.includes("stale-while-revalidate")) {
+  if (headers["cache-control"]) {
     headers["cache-control"] = headers["cache-control"].replace(
-      "stale-while-revalidate",
+      /\bstale-while-revalidate(?!=)/,
       "stale-while-revalidate=2592000", // 30 days
     );
   }

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -10,6 +10,8 @@ if (Object.keys(args).includes("--help")) printHelp();
 
 build({
   buildCommand: args["--build-command"],
+  buildOutputPath: args["--build-output-path"],
+  appPath: args["--app-path"],
   minify: Object.keys(args).includes("--minify"),
 });
 

--- a/packages/tests-e2e/tests/appRouter/isr.test.ts
+++ b/packages/tests-e2e/tests/appRouter/isr.test.ts
@@ -40,3 +40,25 @@ test("Incremental Static Regeneration", async ({ page }) => {
 
   expect(newTime).not.toEqual(finalTime);
 });
+
+test("headers", async ({ page }) => {
+  let responsePromise = page.waitForResponse((response) => {
+    return response.status() === 200;
+  });
+  await page.goto("/isr");
+
+  while (true) {
+    const response = await responsePromise;
+    const headers = response.headers();
+
+    // this was set in middleware
+    if (headers["cache-control"] === "max-age=10, stale-while-revalidate=999") {
+      break;
+    }
+    await wait(1000);
+    responsePromise = page.waitForResponse((response) => {
+      return response.status() === 200;
+    });
+    await page.reload();
+  }
+});


### PR DESCRIPTION
This change introduces a custom `build-output-path` and `app-path` argument which makes it more flexible to support monorepo flavors with decentralised build options.

An example of such a monorepo is an [Nx integrated repository](https://nx.dev/getting-started/tutorials/integrated-repo-tutorial), where apps are placed under `apps/[appName]` and build artifacts are output to `dist/apps/[appName]`. This will allow you to build a more generic script which is being executed from the root of the monorepo.

Besides that a small change is included to also support single-version monorepos, where the `package.json` is exclusively maintained from the root of the monorepo.

These changes are made in a non-breakable manner, paths are being defaulted to the current `process.cwd()` just like before.