### PR TITLE
fix for when there is no cookies lambda@edge

### DIFF
--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -155,10 +155,11 @@ function convertFromCloudFrontRequestEvent(
       }),
       {},
     ),
-    cookies: headers.cookie.reduce((acc, cur) => {
-      const { key, value } = cur;
-      return { ...acc, [key ?? ""]: value };
-    }, {}),
+    cookies:
+      headers.cookie?.reduce((acc, cur) => {
+        const { key, value } = cur;
+        return { ...acc, [key ?? ""]: value };
+      }, {}) ?? {},
   };
 }
 


### PR DESCRIPTION
When there is no cookies on the headers in lambda@edge there will be an exception