### PR TITLE
Fix: middleware cookies

### DIFF
--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -44,6 +44,12 @@ export function middleware(request: NextRequest) {
       headers: requestHeaders,
     },
   });
+
+  // Set cookies in middleware
+  // For: middleware.cookies.test.ts
+  r.cookies.set("from", "middleware");
+  r.cookies.set("with", "love");
+
   return r;
 }
 

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -206,8 +206,7 @@ function convertToApiGatewayProxyResultV2(
     });
 
   let cookies = result.headers["set-cookie"];
-  // Set-Cookies as a comma delimited string is NOT a standard, but
-  // in the context of AWS,
+  // AWS cookies are in a single `set-cookie` string, delimited by a comma
   if (cookies && !Array.isArray(cookies)) {
     cookies = cookies.split(",").map((c) => c.trim());
   }

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -207,7 +207,7 @@ function convertToApiGatewayProxyResultV2(
 
   let cookies = result.headers["set-cookie"];
   // AWS cookies are in a single `set-cookie` string, delimited by a comma
-  if (cookies && !Array.isArray(cookies)) {
+  if (cookies && typeof cookies === "string") {
     cookies = cookies.split(",").map((c) => c.trim());
   }
   const response: APIGatewayProxyResultV2 = {

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -205,10 +205,16 @@ function convertToApiGatewayProxyResultV2(
       headers[key] = Array.isArray(value) ? value.join(", ") : value.toString();
     });
 
+  let cookies = result.headers["set-cookie"];
+  // Set-Cookies as a comma delimited string is NOT a standard, but
+  // in the context of AWS,
+  if (cookies && !Array.isArray(cookies)) {
+    cookies = cookies.split(",").map((c) => c.trim());
+  }
   const response: APIGatewayProxyResultV2 = {
     statusCode: result.statusCode,
     headers,
-    cookies: result.headers["set-cookie"] as string[] | undefined,
+    cookies: cookies as string[],
     body: result.body,
     isBase64Encoded: result.isBase64Encoded,
   };

--- a/packages/tests-e2e/tests/appRouter/middleware.cookies.test.ts
+++ b/packages/tests-e2e/tests/appRouter/middleware.cookies.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+test("Cookies", async ({ page, context }) => {
+  await page.goto("/");
+
+  const cookies = await context.cookies();
+  const from = cookies.find(({ name }) => name === "from");
+  expect(from?.value).toEqual("middleware");
+
+  const love = cookies.find(({ name }) => name === "with");
+  expect(love?.value).toEqual("love");
+});


### PR DESCRIPTION
The API Gateway Proxy Result v2 expected the `cookies` to be a string array of the cookies. The next-server response `cookies.set` adds them as a single array of strings, delimited by a comma.

Issue: Cookies set in middleware was not being set in the response
Fix: Cookies are returned and set on the browser.