### PR TITLE
Fix cookie parse with "Expire="

### DIFF
--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -9,6 +9,7 @@ import type {
 } from "aws-lambda";
 
 import { debug } from "./logger.js";
+import { parseCookies } from "./util.js";
 
 export type InternalEvent = {
   readonly type: "v1" | "v2" | "cf";
@@ -205,15 +206,10 @@ function convertToApiGatewayProxyResultV2(
       headers[key] = Array.isArray(value) ? value.join(", ") : value.toString();
     });
 
-  let cookies = result.headers["set-cookie"];
-  // AWS cookies are in a single `set-cookie` string, delimited by a comma
-  if (cookies && typeof cookies === "string") {
-    cookies = cookies.split(",").map((c) => c.trim());
-  }
   const response: APIGatewayProxyResultV2 = {
     statusCode: result.statusCode,
     headers,
-    cookies: cookies as string[],
+    cookies: parseCookies(result.headers["set-cookie"]),
     body: result.body,
     isBase64Encoded: result.isBase64Encoded,
   };

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -124,7 +124,7 @@ export function parseCookies(
   if (!cookies) return;
 
   if (typeof cookies === "string") {
-    return cookies.split(/(?<!Expires=\w+),/).map((c) => c.trim());
+    return cookies.split(/(?<!Expires=\w+),/i).map((c) => c.trim());
   }
 
   return cookies;

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -116,3 +116,16 @@ export function unescapeRegex(str: string) {
 
   return path;
 }
+
+// AWS cookies are in a single `set-cookie` string, delimited by a comma
+export function parseCookies(
+  cookies?: string | string[],
+): string[] | undefined {
+  if (!cookies) return;
+
+  if (typeof cookies === "string") {
+    return cookies.split(/(?<!Expires=\w+),/).map((c) => c.trim());
+  }
+
+  return cookies;
+}

--- a/packages/tests-unit/tests/adapter.utils.test.ts
+++ b/packages/tests-unit/tests/adapter.utils.test.ts
@@ -19,11 +19,12 @@ describe("adapter utils", () => {
       ]);
     });
     it("parse multiple cookies", () => {
+      // NOTE: expires is lower case but still works
       const cookies = parseCookies(
-        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/, cookie2=value2; HttpOnly; Secure",
+        "cookie1=value1; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/, cookie2=value2; HttpOnly; Secure",
       );
       expect(cookies).toEqual([
-        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+        "cookie1=value1; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
         "cookie2=value2; HttpOnly; Secure",
       ]);
     });

--- a/packages/tests-unit/tests/adapter.utils.test.ts
+++ b/packages/tests-unit/tests/adapter.utils.test.ts
@@ -1,0 +1,48 @@
+import { parseCookies } from "../../open-next/src/adapters/util";
+
+describe("adapter utils", () => {
+  describe("parseCookies", () => {
+    it("returns undefined if cookies is empty", () => {
+      const cookies = parseCookies("");
+      expect(cookies).toBeUndefined();
+    });
+    it("returns undefined if no cookies", () => {
+      const cookies = parseCookies();
+      expect(cookies).toBeUndefined();
+    });
+    it("parse single cookie", () => {
+      const cookies = parseCookies(
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+      );
+      expect(cookies).toEqual([
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+      ]);
+    });
+    it("parse multiple cookies", () => {
+      const cookies = parseCookies(
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/, cookie2=value2; HttpOnly; Secure",
+      );
+      expect(cookies).toEqual([
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+        "cookie2=value2; HttpOnly; Secure",
+      ]);
+    });
+    it("return if cookies is already an array", () => {
+      const cookies = parseCookies([
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+      ]);
+      expect(cookies).toEqual([
+        "cookie1=value1; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; Path=/",
+      ]);
+    });
+    it("parses w/o Expire", () => {
+      const cookies = parseCookies(
+        "cookie1=value1; HttpOnly; Secure; Path=/, cookie2=value2; HttpOnly=false; Secure=True; Domain=example.com; Path=/api",
+      );
+      expect(cookies).toEqual([
+        "cookie1=value1; HttpOnly; Secure; Path=/",
+        "cookie2=value2; HttpOnly=false; Secure=True; Domain=example.com; Path=/api",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
2.1.3 included a fix that did a basic split on a comma, but that doesn't handle the case where the`Set-Cookie` includes: `Expire=Thu 01, Jan 1970...`