### PR TITLE
Fix : incremental cache fixes

### DIFF
--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -16,8 +16,7 @@ import {
 // import { getDerivedTags } from "next/dist/server/lib/incremental-cache/utils";
 import path from "path";
 
-import { loadBuildId } from "./config/util.js";
-import { awsLogger, debug, error } from "./logger.js";
+import { debug, error } from "./logger.js";
 
 // TODO: Remove this, temporary only to run some tests
 const getDerivedTags = (tags: string[]) => tags;
@@ -105,8 +104,8 @@ type Extension =
 const {
   CACHE_BUCKET_NAME,
   CACHE_BUCKET_KEY_PREFIX,
-  CACHE_BUCKET_REGION,
   CACHE_DYNAMO_TABLE,
+  NEXT_BUILD_ID,
 } = process.env;
 
 export default class S3Cache {
@@ -115,17 +114,9 @@ export default class S3Cache {
   private buildId: string;
 
   constructor(_ctx: CacheHandlerContext) {
-    this.client = new S3Client({
-      region: CACHE_BUCKET_REGION,
-      logger: awsLogger,
-    });
-    this.dynamoClient = new DynamoDBClient({
-      region: CACHE_BUCKET_REGION,
-      logger: awsLogger,
-    });
-    this.buildId = loadBuildId(
-      path.dirname(_ctx.serverDistDir ?? ".next/server"),
-    );
+    this.client = globalThis.S3Client;
+    this.dynamoClient = globalThis.dynamoClient;
+    this.buildId = NEXT_BUILD_ID!;
   }
 
   public async get(key: string, options?: boolean | { fetchCache?: boolean }) {

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -1,4 +1,7 @@
 /* eslint-disable unused-imports/no-unused-imports */
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { S3Client } from "@aws-sdk/client-s3";
+
 // We load every config here so that they are only loaded once
 // and during cold starts
 import {
@@ -13,12 +16,33 @@ import {
   PublicAssets,
   RoutesManifest,
 } from "./config/index.js";
+import { awsLogger } from "./logger.js";
 import { lambdaHandler } from "./plugins/lambdaHandler.js";
 import { setNodeEnv } from "./util.js";
 
 setNodeEnv();
 setBuildIdEnv();
 setNextjsServerWorkingDirectory();
+
+///////////////////////
+// AWS global client //
+///////////////////////
+
+declare global {
+  var S3Client: S3Client;
+  var dynamoClient: DynamoDBClient;
+}
+
+const CACHE_BUCKET_REGION = process.env.CACHE_BUCKET_REGION;
+
+globalThis.S3Client = new S3Client({
+  region: CACHE_BUCKET_REGION,
+  logger: awsLogger,
+});
+globalThis.dynamoClient = new DynamoDBClient({
+  region: CACHE_BUCKET_REGION,
+  logger: awsLogger,
+});
 
 /////////////
 // Handler //

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -13,6 +13,19 @@ import {
 import { minifyAll } from "./minimize-js.js";
 import openNextPlugin from "./plugin.js";
 
+interface DangerousOptions {
+  /**
+   * The dynamo db cache is used for revalidateTags and revalidatePath.
+   * @default false
+   */
+  disableDynamoDBCache?: boolean;
+  /**
+   * The incremental cache is used for ISR and SSG.
+   * Disable this only if you use only SSR
+   * @default false
+   */
+  disableIncrementalCache?: boolean;
+}
 interface BuildOptions {
   /**
    * Minify the server bundle.
@@ -39,6 +52,10 @@ interface BuildOptions {
    * });
    * ```
    */
+  /**
+   * Dangerous options. This break some functionnality but can be useful in some cases.
+   */
+  dangerous?: DangerousOptions;
   buildCommand?: string;
   /**
    * The path to the target folder of build output from the `buildCommand` option (the path which will contain the `.next` and `.open-next` folders). This path is relative from the current process.cwd().
@@ -82,8 +99,10 @@ export async function build(opts: BuildOptions = {}) {
   printHeader("Generating bundle");
   initOutputDir();
   createStaticAssets();
-  createCacheAssets(monorepoRoot);
-  await createServerBundle(monorepoRoot, opts.streaming);
+  if (!options.dangerous?.disableIncrementalCache) {
+    createCacheAssets(monorepoRoot, options.dangerous?.disableDynamoDBCache);
+  }
+  await createServerBundle(monorepoRoot, options.streaming);
   createRevalidationBundle();
   createImageOptimizationBundle();
   createWarmerBundle();
@@ -109,6 +128,8 @@ function normalizeOptions(opts: BuildOptions, root: string) {
     minify: opts.minify ?? Boolean(process.env.OPEN_NEXT_MINIFY) ?? false,
     debug: opts.debug ?? Boolean(process.env.OPEN_NEXT_DEBUG) ?? false,
     buildCommand: opts.buildCommand,
+    dangerous: opts.dangerous,
+    streaming: opts.streaming ?? false,
   };
 }
 
@@ -369,7 +390,7 @@ function createStaticAssets() {
   }
 }
 
-function createCacheAssets(monorepoRoot: string) {
+function createCacheAssets(monorepoRoot: string, disableDynamoDBCache = false) {
   console.info(`Bundling cache assets...`);
 
   const { appBuildOutputPath, outputDir } = options;
@@ -398,89 +419,91 @@ function createCacheAssets(monorepoRoot: string) {
       (file.endsWith(".html") && htmlPages.has(file)),
   );
 
-  // Generate dynamodb data
-  // We need to traverse the cache to find every .meta file
-  const metaFiles: {
-    tag: { S: string };
-    path: { S: string };
-    revalidatedAt: { N: string };
-  }[] = [];
+  if (!disableDynamoDBCache) {
+    // Generate dynamodb data
+    // We need to traverse the cache to find every .meta file
+    const metaFiles: {
+      tag: { S: string };
+      path: { S: string };
+      revalidatedAt: { N: string };
+    }[] = [];
 
-  // Compute dynamodb cache data
-  // Traverse files inside cache to find all meta files and cache tags associated with them
-  traverseFiles(
-    outputPath,
-    (file) => file.endsWith(".meta"),
-    (filePath) => {
-      const fileContent = fs.readFileSync(filePath, "utf8");
-      const fileData = JSON.parse(fileContent);
-      if (fileData.headers?.["x-next-cache-tags"]) {
-        fileData.headers["x-next-cache-tags"]
-          .split(",")
-          .forEach((tag: string) => {
-            // TODO: We should split the tag using getDerivedTags from next.js or maybe use an in house implementation
+    // Compute dynamodb cache data
+    // Traverse files inside cache to find all meta files and cache tags associated with them
+    traverseFiles(
+      outputPath,
+      (file) => file.endsWith(".meta"),
+      (filePath) => {
+        const fileContent = fs.readFileSync(filePath, "utf8");
+        const fileData = JSON.parse(fileContent);
+        if (fileData.headers?.["x-next-cache-tags"]) {
+          fileData.headers["x-next-cache-tags"]
+            .split(",")
+            .forEach((tag: string) => {
+              // TODO: We should split the tag using getDerivedTags from next.js or maybe use an in house implementation
+              metaFiles.push({
+                tag: { S: path.posix.join(buildId, tag.trim()) },
+                path: {
+                  S: path.posix.join(
+                    buildId,
+                    path.relative(outputPath, filePath).replace(".meta", ""),
+                  ),
+                },
+                revalidatedAt: { N: `${Date.now()}` },
+              });
+            });
+        }
+      },
+    );
+
+    // Copy fetch-cache to cache folder
+    const fetchCachePath = path.join(
+      appBuildOutputPath,
+      ".next/cache/fetch-cache",
+    );
+    if (fs.existsSync(fetchCachePath)) {
+      const fetchOutputPath = path.join(outputDir, "cache", "__fetch", buildId);
+      fs.mkdirSync(fetchOutputPath, { recursive: true });
+      fs.cpSync(fetchCachePath, fetchOutputPath, { recursive: true });
+
+      traverseFiles(
+        fetchCachePath,
+        () => true,
+        (filepath) => {
+          const fileContent = fs.readFileSync(filepath, "utf8");
+          const fileData = JSON.parse(fileContent);
+          fileData?.tags?.forEach((tag: string) => {
             metaFiles.push({
-              tag: { S: path.posix.join(buildId, tag.trim()) },
+              tag: { S: path.posix.join(buildId, tag) },
               path: {
                 S: path.posix.join(
                   buildId,
-                  path.relative(outputPath, filePath).replace(".meta", ""),
+                  path.relative(fetchCachePath, filepath),
                 ),
               },
               revalidatedAt: { N: `${Date.now()}` },
             });
           });
-      }
-    },
-  );
+        },
+      );
+    }
 
-  // Copy fetch-cache to cache folder
-  const fetchCachePath = path.join(
-    appBuildOutputPath,
-    ".next/cache/fetch-cache",
-  );
-  if (fs.existsSync(fetchCachePath)) {
-    const fetchOutputPath = path.join(outputDir, "cache", "__fetch", buildId);
-    fs.mkdirSync(fetchOutputPath, { recursive: true });
-    fs.cpSync(fetchCachePath, fetchOutputPath, { recursive: true });
+    if (metaFiles.length > 0) {
+      const providerPath = path.join(outputDir, "dynamodb-provider");
 
-    traverseFiles(
-      fetchCachePath,
-      () => true,
-      (filepath) => {
-        const fileContent = fs.readFileSync(filepath, "utf8");
-        const fileData = JSON.parse(fileContent);
-        fileData?.tags?.forEach((tag: string) => {
-          metaFiles.push({
-            tag: { S: path.posix.join(buildId, tag) },
-            path: {
-              S: path.posix.join(
-                buildId,
-                path.relative(fetchCachePath, filepath),
-              ),
-            },
-            revalidatedAt: { N: `${Date.now()}` },
-          });
-        });
-      },
-    );
-  }
+      esbuildSync({
+        external: ["@aws-sdk/client-dynamodb"],
+        entryPoints: [path.join(__dirname, "adapters", "dynamo-provider.js")],
+        outfile: path.join(providerPath, "index.mjs"),
+        target: ["node18"],
+      });
 
-  if (metaFiles.length > 0) {
-    const providerPath = path.join(outputDir, "dynamodb-provider");
-
-    esbuildSync({
-      external: ["@aws-sdk/client-dynamodb"],
-      entryPoints: [path.join(__dirname, "adapters", "dynamo-provider.js")],
-      outfile: path.join(providerPath, "index.mjs"),
-      target: ["node18"],
-    });
-
-    // TODO: check if metafiles doesn't contain duplicates
-    fs.writeFileSync(
-      path.join(providerPath, "dynamodb-cache.json"),
-      JSON.stringify(metaFiles),
-    );
+      // TODO: check if metafiles doesn't contain duplicates
+      fs.writeFileSync(
+        path.join(providerPath, "dynamodb-cache.json"),
+        JSON.stringify(metaFiles),
+      );
+    }
   }
 }
 
@@ -604,7 +627,7 @@ async function createServerBundle(monorepoRoot: string, streaming = false) {
   addPublicFilesList(outputPath, packagePath);
   injectMiddlewareGeolocation(outputPath, packagePath);
   removeCachedPages(outputPath, packagePath);
-  addCacheHandler(outputPath);
+  addCacheHandler(outputPath, options.dangerous);
 }
 
 function addMonorepoEntrypoint(outputPath: string, packagePath: string) {
@@ -712,13 +735,20 @@ function removeCachedPages(outputPath: string, packagePath: string) {
     );
 }
 
-function addCacheHandler(outputPath: string) {
+function addCacheHandler(outputPath: string, options?: DangerousOptions) {
   esbuildSync({
     external: ["next", "styled-jsx", "react"],
     entryPoints: [path.join(__dirname, "adapters", "cache.js")],
     outfile: path.join(outputPath, "cache.cjs"),
     target: ["node18"],
     format: "cjs",
+    banner: {
+      js: `globalThis.disableIncrementalCache = ${
+        options?.disableIncrementalCache ?? false
+      }; globalThis.disableDynamoDBCache = ${
+        options?.disableDynamoDBCache ?? false
+      };`,
+    },
   });
 }
 

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -14,6 +14,14 @@ build({
   appPath: args["--app-path"],
   minify: Object.keys(args).includes("--minify"),
   streaming: Object.keys(args).includes("--streaming"),
+  dangerous: {
+    disableDynamoDBCache: Object.keys(args).includes(
+      "--dangerously-disable-dynamodb-cache",
+    ),
+    disableIncrementalCache: Object.keys(args).includes(
+      "--dangerously-disable-incremental-cache",
+    ),
+  },
 });
 
 function parseArgs() {


### PR DESCRIPTION
The incremental cache in nextjs is actually recreated on every request, everything inside the constructor of incremental cache is executed several times during the lifetime of a lambda.

This PR should solve several issues with incremental cache :

- An issue arise when the lambda stays alive long enough, you'll get a `EMFILE: too many open files` error. To solve this we replaced `loadBuildId` with `process.env.NEXT_BUILD_ID` and made s3Client and dynamoClient global to the lambda. It should solve this issue :crossed_fingers: 
- The dynamodb provider was not generated when there was no fetch cache, but if you don't use fetch cache but want to use `revalidatePath`, it would not have worked.
- There is 2 new flags, `--dangerously-disable-dynamodb-cache` and `--dangerously-disable-incremental-cache`

When you disable the incremental cache every request to the incremental cache will return null and won't perform any other actions. If you disable the dynamodb cache, `revalidateTags` and `revalidatePath` won't work