### PR TITLE
Allow sharp version override in build

### DIFF
--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -347,10 +347,11 @@ function createImageOptimizationBundle() {
   // For SHARP_IGNORE_GLOBAL_LIBVIPS see: https://github.com/lovell/sharp/blob/main/docs/install.md#aws-lambda
 
   const nodeOutputPath = path.resolve(outputPath);
+  const sharpVersion = process.env.SHARP_VERSION ?? "0.32.5";
 
   //check if we are running in Windows environment then set env variables accordingly.
   cp.execSync(
-    `npm install --arch=arm64 --platform=linux --target=18 --libc=glibc --prefix="${nodeOutputPath}" sharp@0.32.5`,
+    `npm install --arch=arm64 --platform=linux --target=18 --libc=glibc --prefix="${nodeOutputPath}" sharp@${sharpVersion}`,
     {
       stdio: "inherit",
       cwd: appPath,


### PR DESCRIPTION
Update build.ts to allow environment variable driven override of the sharp version, which fixes #243