### PR TITLE
fix cookie redirect matcher

### DIFF
--- a/examples/app-router/app/config-redirect/page.tsx
+++ b/examples/app-router/app/config-redirect/page.tsx
@@ -1,0 +1,8 @@
+export default function RedirectDestination() {
+  return (
+    <div>
+      <h1>I was redirected from next.config.js</h1>
+      <p>/next-config-redirect =&gt; /config-redirect</p>
+    </div>
+  );
+}

--- a/examples/app-router/next.config.js
+++ b/examples/app-router/next.config.js
@@ -17,10 +17,16 @@ const nextConfig = {
         missing: [{ type: "cookie", key: "missing-cookie" }],
       },
       {
+        source: "/next-config-redirect-not-missing",
+        destination: "/config-redirect?missing=true",
+        permanent: true,
+        missing: [{ type: "cookie", key: "from" }], // middleware sets this cookie
+      },
+      {
         source: "/next-config-redirect-has",
         destination: "/config-redirect?has=true",
         permanent: true,
-        has: [{ type: "cookie", key: "from" }], // middleware sets this cookie
+        has: [{ type: "cookie", key: "from" }],
       },
       {
         source: "/next-config-redirect-has-with-value",

--- a/examples/app-router/next.config.js
+++ b/examples/app-router/next.config.js
@@ -8,6 +8,34 @@ const nextConfig = {
   experimental: {
     serverActions: true,
   },
+  redirects: () => {
+    return [
+      {
+        source: "/next-config-redirect-missing",
+        destination: "/config-redirect?missing=true",
+        permanent: true,
+        missing: [{ type: "cookie", key: "missing-cookie" }],
+      },
+      {
+        source: "/next-config-redirect-has",
+        destination: "/config-redirect?has=true",
+        permanent: true,
+        has: [{ type: "cookie", key: "from" }], // middleware sets this cookie
+      },
+      {
+        source: "/next-config-redirect-has-with-value",
+        destination: "/config-redirect?hasWithValue=true",
+        permanent: true,
+        has: [{ type: "cookie", key: "from", value: "middleware" }],
+      },
+      {
+        source: "/next-config-redirect-has-with-bad-value",
+        destination: "/config-redirect?hasWithBadValue=true",
+        permanent: true,
+        has: [{ type: "cookie", key: "from", value: "wrongvalue" }],
+      },
+    ];
+  },
   headers() {
     return [
       {

--- a/packages/open-next/src/adapters/routing/matcher.ts
+++ b/packages/open-next/src/adapters/routing/matcher.ts
@@ -22,14 +22,14 @@ const routeHasMatcher =
     switch (redirect.type) {
       case "header":
         return (
-          headers?.[redirect.key.toLowerCase()] !== "" &&
+          headers?.[redirect.key.toLowerCase()] &&
           new RegExp(redirect.value ?? "").test(
             headers[redirect.key.toLowerCase()] ?? "",
           )
         );
       case "cookie":
         return (
-          cookies?.[redirect.key] !== "" &&
+          cookies?.[redirect.key] &&
           new RegExp(redirect.value ?? "").test(cookies[redirect.key] ?? "")
         );
       case "query":

--- a/packages/open-next/src/adapters/routing/matcher.ts
+++ b/packages/open-next/src/adapters/routing/matcher.ts
@@ -22,14 +22,14 @@ const routeHasMatcher =
     switch (redirect.type) {
       case "header":
         return (
-          headers?.[redirect.key.toLowerCase()] &&
+          !!headers?.[redirect.key.toLowerCase()] &&
           new RegExp(redirect.value ?? "").test(
             headers[redirect.key.toLowerCase()] ?? "",
           )
         );
       case "cookie":
         return (
-          cookies?.[redirect.key] &&
+          !!cookies?.[redirect.key] &&
           new RegExp(redirect.value ?? "").test(cookies[redirect.key] ?? "")
         );
       case "query":

--- a/packages/tests-e2e/tests/appRouter/config.redirect.test.ts
+++ b/packages/tests-e2e/tests/appRouter/config.redirect.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+/**
+ * This tests that the "redirect" config in next.config.js works
+ * 
+ * redirects: () => {
+    return [
+      {
+        source: "/next-config-redirect",
+        destination: "/config-redirect",
+        permanent: true,
+        missing: [{ type: "cookie", key: "missing-cookie" }],
+      },
+    ];
+  },
+ */
+test.describe("Next Config Redirect", () => {
+  test("Missing cookies", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/next-config-redirect-missing");
+
+    await page.waitForURL(`/config-redirect?missing=true`);
+
+    const el = page.getByText("I was redirected from next.config.js", {
+      exact: true,
+    });
+    await expect(el).toBeVisible();
+  });
+  test("Has cookies", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/next-config-redirect-has");
+
+    await page.waitForURL(`/config-redirect?has=true`);
+
+    const el = page.getByText("I was redirected from next.config.js", {
+      exact: true,
+    });
+    await expect(el).toBeVisible();
+  });
+  test("Has cookies with value", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/next-config-redirect-has-with-value");
+
+    await page.waitForURL(`/config-redirect?hasWithValue=true`);
+
+    const el = page.getByText("I was redirected from next.config.js", {
+      exact: true,
+    });
+    await expect(el).toBeVisible();
+  });
+  test("Has cookies with bad value", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/next-config-redirect-has-with-bad-value");
+
+    // did not redirect
+    await page.waitForURL(`/next-config-redirect-has-with-bad-value`);
+
+    // 404 not found
+    const el = page.getByText("This page could not be found.", {
+      exact: true,
+    });
+    await expect(el).toBeVisible();
+  });
+});

--- a/packages/tests-e2e/tests/appRouter/config.redirect.test.ts
+++ b/packages/tests-e2e/tests/appRouter/config.redirect.test.ts
@@ -25,6 +25,18 @@ test.describe("Next Config Redirect", () => {
     });
     await expect(el).toBeVisible();
   });
+  test("Not missing cookies", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/next-config-redirect-not-missing");
+
+    // the cookie was not missing, so no redirects
+    await page.waitForURL("/next-config-redirect-not-missing");
+
+    const el = page.getByText("This page could not be found.", {
+      exact: true,
+    });
+    await expect(el).toBeVisible();
+  });
   test("Has cookies", async ({ page }) => {
     await page.goto("/");
     await page.goto("/next-config-redirect-has");


### PR DESCRIPTION
When `cookie['key-does-not-exist-and-will-be-undefined']`, the cookie matcher logic would return `true` because `undefined !== ""`

See: `cookies?.[redirect.key] !== ""`