### PR TITLE
Fix trailing slash

### DIFF
--- a/examples/pages-router/next.config.js
+++ b/examples/pages-router/next.config.js
@@ -5,6 +5,8 @@ const nextConfig = {
   reactStrictMode: true,
   output: "standalone",
   outputFileTracing: "../sst",
+  rewrites: () => [{ source: "/rewrite", destination: "/" }],
+  trailingSlash: true,
 };
 
 module.exports = nextConfig;

--- a/packages/open-next/src/adapters/config/util.ts
+++ b/packages/open-next/src/adapters/config/util.ts
@@ -45,11 +45,13 @@ export function loadRoutesManifest(nextDir: string) {
   };
 
   return {
-    rewrites: {
-      beforeFiles: routesManifest.rewrites.beforeFiles ?? [],
-      afterFiles: routesManifest.rewrites.afterFiles ?? [],
-      fallback: routesManifest.rewrites.fallback ?? [],
-    },
+    rewrites: Array.isArray(routesManifest.rewrites)
+      ? { beforeFiles: [], afterFiles: routesManifest.rewrites, fallback: [] }
+      : {
+          beforeFiles: routesManifest.rewrites.beforeFiles ?? [],
+          afterFiles: routesManifest.rewrites.afterFiles ?? [],
+          fallback: routesManifest.rewrites.fallback ?? [],
+        },
     redirects: routesManifest.redirects ?? [],
     routes: {
       static: routesManifest.staticRoutes ?? [],

--- a/packages/open-next/src/adapters/types/next-types.ts
+++ b/packages/open-next/src/adapters/types/next-types.ts
@@ -101,11 +101,13 @@ export interface RoutesManifest {
   dynamicRoutes: RouteDefinition[];
   staticRoutes: RouteDefinition[];
   dataRoutes: DataRouteDefinition[];
-  rewrites: {
-    beforeFiles: RewriteDefinition[];
-    afterFiles: RewriteDefinition[];
-    fallback: RewriteDefinition[];
-  };
+  rewrites:
+    | {
+        beforeFiles: RewriteDefinition[];
+        afterFiles: RewriteDefinition[];
+        fallback: RewriteDefinition[];
+      }
+    | RewriteDefinition[];
   redirects: RedirectDefinition[];
   headers?: Header[];
 }

--- a/packages/tests-e2e/tests/pagesRouter/isr.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/isr.test.ts
@@ -4,8 +4,8 @@ import { expect, test } from "@playwright/test";
 test("Incremental Static Regeneration", async ({ page }) => {
   test.setTimeout(45000);
   await page.goto("/");
-  await page.locator("[href='/isr']").click();
-  await page.waitForURL("/isr");
+  await page.locator("[href='/isr/']").click();
+  await page.waitForURL("/isr/");
   // Load the page a couple times to regenerate ISR
 
   let el = page.getByText("Time:");

--- a/packages/tests-e2e/tests/pagesRouter/rewrite.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/rewrite.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test("Single Rewrite", async ({ page }) => {
+  await page.goto("/rewrite");
+
+  let el = page.getByText("Nextjs Pages Router");
+  await expect(el).toBeVisible();
+});

--- a/packages/tests-e2e/tests/pagesRouter/ssr.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/ssr.test.ts
@@ -3,9 +3,9 @@ import { expect, test } from "@playwright/test";
 
 test("Server Side Render", async ({ page }) => {
   await page.goto("/");
-  await page.locator('[href="/ssr"]').click();
+  await page.locator('[href="/ssr/"]').click();
 
-  await page.waitForURL("/ssr");
+  await page.waitForURL("/ssr/");
   let el = page.getByText("Time:");
   await expect(el).toBeVisible();
   let time = await el.textContent();

--- a/packages/tests-e2e/tests/pagesRouter/trailing.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/trailing.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "@playwright/test";
+
+test("trailingSlash redirect", async ({ page }) => {
+  const response = await page.goto("/ssr");
+
+  expect(response?.request().redirectedFrom()?.url()).toMatch(/\/ssr$/);
+  expect(response?.request().url()).toMatch(/\/ssr\/$/);
+});


### PR DESCRIPTION
This PR solve issue with `trailingSlash` config in `next.config.js`. Fix #260 

It also solve an issue when people use `rewrites` config in `next.config.js` using array instead of the more complex 
```js
rewrites: () => ({
beforeFiles: [...],
afterFiles: [...],
...
})
```