### PR TITLE
Feature/rewrite with query string

### DIFF
--- a/examples/app-pages-router/app/rewrite-destination/page.tsx
+++ b/examples/app-pages-router/app/rewrite-destination/page.tsx
@@ -1,3 +1,12 @@
-export default function RewriteDestination() {
-  return <div>Rewritten Destination</div>;
+export default function RewriteDestination({
+  searchParams,
+}: {
+  searchParams: { a: string };
+}) {
+  return (
+    <div>
+      <div>Rewritten Destination</div>
+      <div>a: {searchParams.a}</div>
+    </div>
+  );
 }

--- a/examples/app-pages-router/middleware.ts
+++ b/examples/app-pages-router/middleware.ts
@@ -10,6 +10,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(u);
   } else if (path === "/rewrite") {
     const u = new URL("/rewrite-destination", `${protocol}://${host}`);
+    u.searchParams.set("a", "b");
     return NextResponse.rewrite(u);
   } else if (path === "/api/middleware") {
     return new NextResponse(JSON.stringify({ hello: "middleware" }), {

--- a/packages/open-next/src/adapters/routing/middleware.ts
+++ b/packages/open-next/src/adapters/routing/middleware.ts
@@ -137,8 +137,15 @@ export async function handleMiddleware(
   // NOTE: the header was added to `req` from above
   const rewriteUrl = responseHeaders.get("x-middleware-rewrite");
   let rewritten = false;
+  let middlewareQueryString = internalEvent.query;
   if (rewriteUrl) {
-    req.url = new URL(rewriteUrl).pathname;
+    const rewriteUrlObject = new URL(rewriteUrl);
+    req.url = rewriteUrlObject.pathname;
+    rewriteUrlObject.searchParams.forEach((v: string, k: string) => {
+      if (!middlewareQueryString[k]) {
+        middlewareQueryString[k] = v;
+      }
+    });
     rewritten = true;
   }
 
@@ -162,7 +169,7 @@ export async function handleMiddleware(
     headers: { ...internalEvent.headers, ...reqHeaders },
     body: internalEvent.body,
     method: internalEvent.method,
-    query: internalEvent.query,
+    query: middlewareQueryString,
     cookies: internalEvent.cookies,
     remoteAddress: internalEvent.remoteAddress,
   };

--- a/packages/tests-e2e/tests/appPagesRouter/middleware.rewrite.test.ts
+++ b/packages/tests-e2e/tests/appPagesRouter/middleware.rewrite.test.ts
@@ -7,10 +7,13 @@ test("Middleware Rewrite", async ({ page }) => {
   await page.waitForURL(`/rewrite`);
   let el = page.getByText("Rewritten Destination", { exact: true });
   await expect(el).toBeVisible();
-
+  el = page.getByText("a: b", { exact: true });
+  await expect(el).toBeVisible();
   // Loading page should also rewrite
   await page.goto(`/rewrite`);
   await page.waitForURL(`/rewrite`);
   el = page.getByText("Rewritten Destination", { exact: true });
+  await expect(el).toBeVisible();
+  el = page.getByText("a: b", { exact: true });
   await expect(el).toBeVisible();
 });


### PR DESCRIPTION
Hello, I noticed that when using the rewrite function, any query string is lost. To describe the scenario in the first commit, I'm adding a parameter "a" to the "apppagesrouter" component. When I render the page locally, I get "a: b," while the online version displays "a: " because the query string parameter "a" is lost when the middleware composes the rewrite URLs. With the second commit, there's a proposed solution that I'll leave for you to evaluate.