### PR TITLE
Fix swr client inconsistencies

### DIFF
--- a/.changeset/lazy-pens-bake.md
+++ b/.changeset/lazy-pens-bake.md
@@ -1,0 +1,19 @@
+---
+"open-next": minor
+---
+
+Fix inconsistencies with swr and isr (#289)
+
+Exclude manifest.json, robots.txt and sitemap.xml from routing matcher (#287)
+
+Feature/rewrite with query string (#281)
+
+Double chunk DDB batch writes to not overwhelm DDB on load (#293) 
+
+fix: copy favicon.ico from app dir (#301)
+
+fix: XML Malformed Error DeleteObjectsCommand (#300) 
+
+Fix external rewrite (#299)
+
+Perf Reduce s3 calls (#295) 

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -137,6 +137,7 @@ declare global {
   var dynamoClient: DynamoDBClient;
   var disableDynamoDBCache: boolean;
   var disableIncrementalCache: boolean;
+  var lastModified: number;
 }
 
 export default class S3Cache {
@@ -201,6 +202,7 @@ export default class S3Cache {
         // If some tags are stale we need to force revalidation
         return null;
       }
+      globalThis.lastModified = lastModified;
       if (cacheData.type === "route") {
         return {
           lastModified: LastModified?.getTime(),

--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -134,10 +134,13 @@ export async function revalidateIfRequired(
     const hash = (str: string) =>
       crypto.createHash("md5").update(str).digest("hex");
 
+    const lastModified =
+      globalThis.lastModified > 0 ? globalThis.lastModified : "";
+
     await sqsClient.send(
       new SendMessageCommand({
         QueueUrl: REVALIDATION_QUEUE_URL,
-        MessageDeduplicationId: hash(`${rawPath}-${headers.etag}`),
+        MessageDeduplicationId: hash(`${rawPath}-${lastModified}`),
         MessageBody: JSON.stringify({ host, url: revalidateUrl }),
         MessageGroupId: generateMessageGroupId(rawPath),
       }),

--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -209,7 +209,8 @@ export function fixISRHeaders(headers: Record<string, string | undefined>) {
     const match = headers[CommonHeaders.CACHE_CONTROL]?.match(regex);
     const sMaxAge = match ? parseInt(match[1]) : undefined;
 
-    if (sMaxAge) {
+    // 31536000 is the default s-maxage value for SSG pages
+    if (sMaxAge && sMaxAge !== 31536000) {
       const remainingTtl = Math.max(sMaxAge - age, 1);
       headers[
         CommonHeaders.CACHE_CONTROL

--- a/packages/open-next/src/adapters/routing/middleware.ts
+++ b/packages/open-next/src/adapters/routing/middleware.ts
@@ -44,6 +44,8 @@ export async function handleMiddleware(
   const { rawPath, query } = internalEvent;
   const hasMatch = middleMatch.some((r) => r.test(rawPath));
   if (!hasMatch) return internalEvent;
+  // We bypass the middleware if the request is internal
+  if (internalEvent.headers["x-isr"]) return internalEvent;
 
   const req = new IncomingMessage(internalEvent);
   const res = new ServerlessResponse({


### PR DESCRIPTION
This PR aims to solve an issue regarding inconsistencies between rsc (or json) data and html data for ISR.

Until now next set the `cache-control` header to `s-maxage=X, stale-while-revalidate` with `X` being the revalidate value.
This cause inconsistencies between rsc and html data due to cdn caching especially for big revalidate value.

For example with `revalidate=3600`, rsc and html could be out of sync by a maximum of 3599 seconds. It is assuming someone accessed the html at `t=0` and no one accessed the rsc until `t=3599`. 
This behaviour is exacerbated with app dir since every `<Link />` pointing to the same route from a different route will result in a different rsc call and thus a different cdn cache entry.

This PR also fix the 5 min deduplication window of the SQS queue.