### PR TITLE
Double chunk DDB batch writes to not overwhelm DDB on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ AWS link: https://d1gwt3w78t4dm3.cloudfront.net
 
 Vercel link: https://open-next.vercel.app
 
+## Configuration
+
+### Environment variables
+
+- DYNAMO_BATCH_WRITE_COMMAND_CONCURRENCY: The number of concurrent batch write commands to DynamoDB. Defaults to 4 in an effort to leave plenty of DynamoDB write request capacity for the production load.
+
 ## Contribute
 
 To run `OpenNext` locally:

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -15,6 +15,7 @@ import {
 import path from "path";
 
 import { debug, error } from "./logger.js";
+import { chunk } from "./util.js";
 
 interface CachedFetchValue {
   kind: "FETCH";
@@ -420,7 +421,7 @@ export default class S3Cache {
     try {
       if (disableDynamoDBCache) return;
       await Promise.all(
-        this.chunkArray(req, 25).map((Items) => {
+        chunk(req, 25).map((Items) => {
           return this.dynamoClient.send(
             new BatchWriteItemCommand({
               RequestItems: {
@@ -453,14 +454,6 @@ export default class S3Cache {
       tag: { S: this.buildDynamoKey(tags) },
       revalidatedAt: { N: `${Date.now()}` },
     };
-  }
-
-  private chunkArray<T>(array: T[], chunkSize: number) {
-    const chunks = [];
-    for (let i = 0; i < array.length; i += chunkSize) {
-      chunks.push(array.slice(i, i + chunkSize));
-    }
-    return chunks;
   }
 
   // S3 handling

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -14,6 +14,7 @@ import {
 } from "@aws-sdk/client-s3";
 import path from "path";
 
+import { MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT } from "./constants.js";
 import { debug, error } from "./logger.js";
 import { chunk } from "./util.js";
 
@@ -421,7 +422,7 @@ export default class S3Cache {
     try {
       if (disableDynamoDBCache) return;
       await Promise.all(
-        chunk(req, 25).map((Items) => {
+        chunk(req, MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT).map((Items) => {
           return this.dynamoClient.send(
             new BatchWriteItemCommand({
               RequestItems: {

--- a/packages/open-next/src/adapters/constants.ts
+++ b/packages/open-next/src/adapters/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT = 25;

--- a/packages/open-next/src/adapters/constants.ts
+++ b/packages/open-next/src/adapters/constants.ts
@@ -1,1 +1,25 @@
 export const MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT = 25;
+
+/**
+ * Sending to dynamo X commands at a time, using about X * 25 write units per batch to not overwhelm DDB
+ * and give production plenty of room to work with. With DDB Response times, you can expect about 10 batches per second.
+ */
+const DEFAULT_DYNAMO_BATCH_WRITE_COMMAND_CONCURRENCY = 4;
+
+export const getDynamoBatchWriteCommandConcurrency = (): number => {
+  const dynamoBatchWriteCommandConcurrencyFromEnv =
+    process.env.DYNAMO_BATCH_WRITE_COMMAND_CONCURRENCY;
+  const parsedDynamoBatchWriteCommandConcurrencyFromEnv =
+    dynamoBatchWriteCommandConcurrencyFromEnv
+      ? parseInt(dynamoBatchWriteCommandConcurrencyFromEnv)
+      : undefined;
+
+  if (
+    parsedDynamoBatchWriteCommandConcurrencyFromEnv &&
+    !isNaN(parsedDynamoBatchWriteCommandConcurrencyFromEnv)
+  ) {
+    return parsedDynamoBatchWriteCommandConcurrencyFromEnv;
+  }
+
+  return DEFAULT_DYNAMO_BATCH_WRITE_COMMAND_CONCURRENCY;
+};

--- a/packages/open-next/src/adapters/dynamo-provider.ts
+++ b/packages/open-next/src/adapters/dynamo-provider.ts
@@ -5,6 +5,7 @@ import {
 import { CdkCustomResourceEvent, CdkCustomResourceResponse } from "aws-lambda";
 import { readFileSync } from "fs";
 
+import { MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT } from "./constants.js";
 import { chunk } from "./util.js";
 
 const PHYSICAL_RESOURCE_ID = "dynamodb-cache";
@@ -34,8 +35,6 @@ export async function handler(
       return remove();
   }
 }
-
-const MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT = 25;
 
 /**
  * Sending to dynamo X commands at a time, using about X * 25 write units per batch to not overwhelm DDB

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -38,3 +38,13 @@ export function parseCookies(
 
   return cookies;
 }
+
+export function chunk<T>(items: T[], chunkSize: number): T[][] {
+  const chunked = items.reduce((acc, curr, i) => {
+    const chunkIndex = Math.floor(i / chunkSize);
+    acc[chunkIndex] = [...(acc[chunkIndex] ?? []), curr];
+    return acc;
+  }, new Array<T[]>());
+
+  return chunked;
+}

--- a/packages/open-next/src/adapters/util.ts
+++ b/packages/open-next/src/adapters/util.ts
@@ -39,6 +39,12 @@ export function parseCookies(
   return cookies;
 }
 
+/**
+ * Create an array of arrays of size `chunkSize` from `items`
+ * @param items Array of T
+ * @param chunkSize size of each chunk
+ * @returns T[][]
+ */
 export function chunk<T>(items: T[], chunkSize: number): T[][] {
   const chunked = items.reduce((acc, curr, i) => {
     const chunkIndex = Math.floor(i / chunkSize);


### PR DESCRIPTION
For larger pre-rendered sites, throwing thousands of requests at DDB immediately overwhelms the throughput.

This change mitigates this.