### PR TITLE
fix: copy favicon.ico from app dir

### DIFF
--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -377,7 +377,7 @@ function createStaticAssets() {
   // - .next/BUILD_ID => _next/BUILD_ID
   // - .next/static   => _next/static
   // - public/*       => *
-  // - src/app/favicon.ico => favicon.ico
+  // - app/favicon.ico or src/app/favicon.ico  => favicon.ico
   fs.copyFileSync(
     path.join(appBuildOutputPath, ".next/BUILD_ID"),
     path.join(outputPath, "BUILD_ID"),
@@ -391,7 +391,11 @@ function createStaticAssets() {
     fs.cpSync(appPublicPath, outputPath, { recursive: true });
   }
 
-  const faviconPath = path.join(appPath, "src", "app", "favicon.ico");
+  const appSrcPath = fs.existsSync(path.join(appPath, "src"))
+    ? "src/app"
+    : "app";
+
+  const faviconPath = path.join(appPath, appSrcPath, "favicon.ico");
 
   if (fs.existsSync(faviconPath)) {
     fs.copyFileSync(faviconPath, path.join(outputPath, "favicon.ico"));

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -366,7 +366,7 @@ function createImageOptimizationBundle() {
 function createStaticAssets() {
   console.info(`Bundling static assets...`);
 
-  const { appBuildOutputPath, appPublicPath, outputDir } = options;
+  const { appBuildOutputPath, appPublicPath, outputDir, appPath } = options;
 
   // Create output folder
   const outputPath = path.join(outputDir, "assets");
@@ -377,6 +377,7 @@ function createStaticAssets() {
   // - .next/BUILD_ID => _next/BUILD_ID
   // - .next/static   => _next/static
   // - public/*       => *
+  // - src/app/favicon.ico => *
   fs.copyFileSync(
     path.join(appBuildOutputPath, ".next/BUILD_ID"),
     path.join(outputPath, "BUILD_ID"),
@@ -388,6 +389,12 @@ function createStaticAssets() {
   );
   if (fs.existsSync(appPublicPath)) {
     fs.cpSync(appPublicPath, outputPath, { recursive: true });
+  }
+
+  const faviconPath = path.join(appPath, "src", "app", "favicon.ico");
+
+  if (fs.existsSync(faviconPath)) {
+    fs.copyFileSync(faviconPath, path.join(outputPath, "favicon.ico"));
   }
 }
 

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -377,7 +377,7 @@ function createStaticAssets() {
   // - .next/BUILD_ID => _next/BUILD_ID
   // - .next/static   => _next/static
   // - public/*       => *
-  // - src/app/favicon.ico => *
+  // - src/app/favicon.ico => favicon.ico
   fs.copyFileSync(
     path.join(appBuildOutputPath, ".next/BUILD_ID"),
     path.join(outputPath, "BUILD_ID"),


### PR DESCRIPTION
Fixes #158 

This PR adds functionality to check for the existence of favicon.ico in the `src/app/` or `app/` directory and, if present, copies it to the `.open-next/assets` directory.