### PR TITLE
fix: setting the right tag values for fetch cache

### DIFF
--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -306,7 +306,7 @@ export default class S3Cache {
     // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
     const derivedTags: string[] =
       data?.kind === "FETCH"
-        ? ctx?.tags ?? []
+        ? ctx?.tags ?? data?.data?.tags ?? [] // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
         : data?.kind === "PAGE"
         ? data.headers?.["x-next-cache-tags"]?.split(",") ?? []
         : [];

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -70,6 +70,14 @@ type IncrementalCacheValue =
   | CachedFetchValue
   | CachedRouteValue;
 
+type IncrementalCacheContext = {
+  revalidate?: number | false | undefined;
+  fetchCache?: boolean | undefined;
+  fetchUrl?: string | undefined;
+  fetchIdx?: number | undefined;
+  tags?: string[] | undefined;
+};
+
 interface CacheHandlerContext {
   fs?: never;
   dev?: boolean;
@@ -254,7 +262,11 @@ export default class S3Cache {
     return null;
   }
 
-  async set(key: string, data?: IncrementalCacheValue): Promise<void> {
+  async set(
+    key: string,
+    data?: IncrementalCacheValue,
+    ctx?: IncrementalCacheContext,
+  ): Promise<void> {
     if (globalThis.disableIncrementalCache) {
       return;
     }
@@ -298,7 +310,7 @@ export default class S3Cache {
     // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
     const derivedTags: string[] =
       data?.kind === "FETCH"
-        ? data.data.tags ?? []
+        ? ctx?.tags ?? []
         : data?.kind === "PAGE"
         ? data.headers?.["x-next-cache-tags"]?.split(",") ?? []
         : [];


### PR DESCRIPTION
Right now the tag property is always empty, I tried to check in the nextjs code base the reason and i found [this relevant code](https://github.com/vercel/next.js/blob/b8b1ec24a259ac1a42a513971259bda62738dd47/packages/next/src/server/lib/patch-fetch.ts#L479C1-L498C18) 
this code was introduced in [this PR](https://github.com/vercel/next.js/commit/2eef7754728b3db8df8b1f52def0a47c8f0baed5#diff-4c54e369ddb9a2db1eed95fe1d678f94c8e82c540204475d42c78e49bf4f223a), So I'm wondering how we should manage that for older versions of nextjs that don't have that change.

Also ideally I would like to add some tests to the open-next repo to make sure that revalidateTag works ok but I still don't understand fully the setup and how to write that test so this PR is probably a WIP