### PR TITLE
Fix getHeaders crash

### DIFF
--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -47,7 +47,8 @@ export async function proxyRequest(
       proxyRes.on("end", function () {
         const newBody = Buffer.concat(body).toString();
         debug(`Proxying response`, {
-          headers: proxyRes.getHeaders(),
+          // @ts-ignore TODO: get correct type for the proxyRes
+          headers: proxyRes.getHeaders?.() || proxyRes.headers,
           body: newBody,
         });
         res.end(newBody);


### PR DESCRIPTION
This is a minor fix on a crash, but needs investigation later.


I tried to pipe the request instead and it works for some sites...
Need to look into https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/router-utils/proxy-request.ts
I tried creating the stream from the request but that didn't work 🤷 