### PR TITLE
Added --package-json option to specify package json path

### DIFF
--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -68,6 +68,11 @@ interface BuildOptions {
    * @default "."
    */
   appPath?: string;
+
+  /**
+   * The path to the package.json file. This path is relative from the current process.cwd().
+   */
+  packageJsonPath?: string;
 }
 
 const require = topLevelCreateRequire(import.meta.url);
@@ -117,7 +122,16 @@ function normalizeOptions(opts: BuildOptions, root: string) {
   const appPath = path.join(process.cwd(), opts.appPath || ".");
   const buildOutputPath = path.join(process.cwd(), opts.buildOutputPath || ".");
   const outputDir = path.join(buildOutputPath, ".open-next");
-  const nextPackageJsonPath = findNextPackageJsonPath(appPath, root);
+
+  let nextPackageJsonPath: string;
+  if (opts.packageJsonPath) {
+    const _pkgPath = path.join(process.cwd(), opts.packageJsonPath);
+    nextPackageJsonPath = _pkgPath.endsWith("package.json")
+      ? _pkgPath
+      : path.join(_pkgPath, "./package.json");
+  } else {
+    nextPackageJsonPath = findNextPackageJsonPath(appPath, root);
+  }
   return {
     openNextVersion: getOpenNextVersion(),
     nextVersion: getNextVersion(nextPackageJsonPath),

--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -12,6 +12,7 @@ build({
   buildCommand: args["--build-command"],
   buildOutputPath: args["--build-output-path"],
   appPath: args["--app-path"],
+  packageJsonPath: args["--package-json"],
   minify: Object.keys(args).includes("--minify"),
   streaming: Object.keys(args).includes("--streaming"),
   dangerous: {


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/sst/open-next/issues/296)  by adding a `--package-json` option to allow it to run with monorepos (In my specific case in a nx workspace).