### PR TITLE
Changes encoding on cache.body from utf8 to base64

### DIFF
--- a/.changeset/wicked-comics-trade.md
+++ b/.changeset/wicked-comics-trade.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Changes encoding on cache.body for binary data

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -226,7 +226,12 @@ export default class S3Cache {
           lastModified: LastModified?.getTime(),
           value: {
             kind: "ROUTE",
-            body: Buffer.from(cacheData.body ?? Buffer.alloc(0), "base64"),
+            body: Buffer.from(
+              cacheData.body ?? Buffer.alloc(0),
+              meta?.headers?.["content-type"]?.includes("application/json")
+                ? "utf8"
+                : "base64",
+            ),
             status: meta?.status,
             headers: meta?.headers,
           },
@@ -276,7 +281,9 @@ export default class S3Cache {
         "cache",
         JSON.stringify({
           type: "route",
-          body: body.toString("base64"),
+          body: body.toString(
+            headers["content-type"] === "application/json" ? "utf8" : "base64",
+          ),
           meta: {
             status,
             headers,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -13,6 +13,7 @@ import {
 } from "@aws-sdk/client-s3";
 import path from "path";
 
+import { isBinaryContentType } from "./binary.js";
 import { MAX_DYNAMO_BATCH_WRITE_ITEM_COUNT } from "./constants.js";
 import { debug, error, warn } from "./logger.js";
 import { chunk } from "./util.js";
@@ -228,7 +229,7 @@ export default class S3Cache {
             kind: "ROUTE",
             body: Buffer.from(
               cacheData.body ?? Buffer.alloc(0),
-              String(meta?.headers?.["content-type"]).startsWith("image")
+              isBinaryContentType(String(meta?.headers?.["content-type"]))
                 ? "base64"
                 : "utf8",
             ),
@@ -282,7 +283,7 @@ export default class S3Cache {
         JSON.stringify({
           type: "route",
           body: body.toString(
-            String(headers["content-type"]).startsWith("image")
+            isBinaryContentType(String(headers["content-type"]))
               ? "base64"
               : "utf8",
           ),

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -226,7 +226,7 @@ export default class S3Cache {
           lastModified: LastModified?.getTime(),
           value: {
             kind: "ROUTE",
-            body: Buffer.from(cacheData.body ?? Buffer.alloc(0)),
+            body: Buffer.from(cacheData.body ?? Buffer.alloc(0), "base64"),
             status: meta?.status,
             headers: meta?.headers,
           },
@@ -276,7 +276,7 @@ export default class S3Cache {
         "cache",
         JSON.stringify({
           type: "route",
-          body: body.toString("utf8"),
+          body: body.toString("base64"),
           meta: {
             status,
             headers,

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -228,9 +228,9 @@ export default class S3Cache {
             kind: "ROUTE",
             body: Buffer.from(
               cacheData.body ?? Buffer.alloc(0),
-              meta?.headers?.["content-type"]?.includes("application/json")
-                ? "utf8"
-                : "base64",
+              String(meta?.headers?.["content-type"]).startsWith("image")
+                ? "base64"
+                : "utf8",
             ),
             status: meta?.status,
             headers: meta?.headers,
@@ -282,7 +282,9 @@ export default class S3Cache {
         JSON.stringify({
           type: "route",
           body: body.toString(
-            headers["content-type"] === "application/json" ? "utf8" : "base64",
+            String(headers["content-type"]).startsWith("image")
+              ? "base64"
+              : "utf8",
           ),
           meta: {
             status,

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -504,7 +504,9 @@ function createCacheAssets(monorepoRoot: string, disableDynamoDBCache = false) {
         ? JSON.parse(fs.readFileSync(files.json, "utf8"))
         : undefined,
       rsc: files.rsc ? fs.readFileSync(files.rsc, "utf8") : undefined,
-      body: files.body ? fs.readFileSync(files.body, "utf8") : undefined,
+      body: files.body
+        ? fs.readFileSync(files.body).toString("base64")
+        : undefined,
     };
     fs.writeFileSync(cacheFilePath, JSON.stringify(cacheFileContent));
   });

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -494,18 +494,25 @@ function createCacheAssets(monorepoRoot: string, disableDynamoDBCache = false) {
 
   // Generate cache file
   Object.entries(cacheFilesPath).forEach(([cacheFilePath, files]) => {
+    const cacheFileMeta = files.meta
+      ? JSON.parse(fs.readFileSync(files.meta, "utf8"))
+      : undefined;
     const cacheFileContent = {
       type: files.body ? "route" : files.json ? "page" : "app",
-      meta: files.meta
-        ? JSON.parse(fs.readFileSync(files.meta, "utf8"))
-        : undefined,
+      meta: cacheFileMeta,
       html: files.html ? fs.readFileSync(files.html, "utf8") : undefined,
       json: files.json
         ? JSON.parse(fs.readFileSync(files.json, "utf8"))
         : undefined,
       rsc: files.rsc ? fs.readFileSync(files.rsc, "utf8") : undefined,
       body: files.body
-        ? fs.readFileSync(files.body).toString("base64")
+        ? fs
+            .readFileSync(files.body)
+            .toString(
+              cacheFileMeta.headers["content-type"] === "application/json"
+                ? "utf8"
+                : "base64",
+            )
         : undefined,
     };
     fs.writeFileSync(cacheFilePath, JSON.stringify(cacheFileContent));

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -10,6 +10,7 @@ import {
   buildSync,
 } from "esbuild";
 
+import { isBinaryContentType } from "./adapters/binary.js";
 import logger from "./logger.js";
 import { minifyAll } from "./minimize-js.js";
 import openNextPlugin from "./plugin.js";
@@ -509,7 +510,7 @@ function createCacheAssets(monorepoRoot: string, disableDynamoDBCache = false) {
         ? fs
             .readFileSync(files.body)
             .toString(
-              cacheFileMeta.headers["content-type"].startsWith("image")
+              isBinaryContentType(cacheFileMeta.headers["content-type"])
                 ? "base64"
                 : "utf8",
             )

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -509,9 +509,9 @@ function createCacheAssets(monorepoRoot: string, disableDynamoDBCache = false) {
         ? fs
             .readFileSync(files.body)
             .toString(
-              cacheFileMeta.headers["content-type"] === "application/json"
-                ? "utf8"
-                : "base64",
+              cacheFileMeta.headers["content-type"].startsWith("image")
+                ? "base64"
+                : "utf8",
             )
         : undefined,
     };


### PR DESCRIPTION
[Code generated icons](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons#generate-icons-using-code-js-ts-tsx) are cached as routes with a binary body. open-next currently merges the route meta and utf-8 encoded body into a single *.cache file, which can be problematic for binary png data. This PR simply changes the encoding on the cached route body from `utf8` to `base64` to preserve binary data.

Alternatively, we could preserve the utf-8 encoding on json routes, and only apply base64 when necessary according to `meta.headers.content-type`? 