### PR TITLE
fix: try to match errors, fall back to just adding raw key / value pare

### DIFF
--- a/.changeset/afraid-ducks-speak.md
+++ b/.changeset/afraid-ducks-speak.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+try to match errors, fallback to raw key/value pair

--- a/packages/open-next/src/adapters/routing/matcher.ts
+++ b/packages/open-next/src/adapters/routing/matcher.ts
@@ -105,9 +105,14 @@ export function addNextConfigHeaders(
       const fromSource = match(source);
       const _match = fromSource(rawPath);
       headers.forEach((h) => {
-        const key = convertMatch(_match, compile(h.key), h.key);
-        const value = convertMatch(_match, compile(h.value), h.value);
-        requestHeaders[key] = value;
+        try {
+          const key = convertMatch(_match, compile(h.key), h.key);
+          const value = convertMatch(_match, compile(h.value), h.value);
+          requestHeaders[key] = value;
+        } catch {
+          debug("Error matching header ", h.key, ' with value ', h.value);
+          requestHeaders[h.key] = h.value;
+        }
       });
     }
   }

--- a/packages/open-next/src/adapters/routing/matcher.ts
+++ b/packages/open-next/src/adapters/routing/matcher.ts
@@ -110,7 +110,7 @@ export function addNextConfigHeaders(
           const value = convertMatch(_match, compile(h.value), h.value);
           requestHeaders[key] = value;
         } catch {
-          debug("Error matching header ", h.key, ' with value ', h.value);
+          debug("Error matching header ", h.key, " with value ", h.value);
           requestHeaders[h.key] = h.value;
         }
       });


### PR DESCRIPTION
Hi,

Current logic for matching headers does not 100% match how nextjs deals with it. For example when you have a `Content-Security-Policy` header which contains urls like `https://google.com` then the matching will fail resulting in an Internal Server Error.

This PR adds a small bandage so non matched headers are just returned as-is ensuring no Internal Server Error is triggered.

Ideally we have same logic as Nextjs