### PR TITLE
fix(open-next): use dynamic import handler for monorepo entrypoint

### DIFF
--- a/.changeset/moody-camels-help.md
+++ b/.changeset/moody-camels-help.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+use dynamic import handler for monorepo entrypoint

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -735,7 +735,12 @@ function addMonorepoEntrypoint(outputPath: string, packagePath: string) {
   const packagePosixPath = packagePath.split(path.sep).join(path.posix.sep);
   fs.writeFileSync(
     path.join(outputPath, "index.mjs"),
-    [`export * from "./${packagePosixPath}/index.mjs";`].join(""),
+    [
+      `export const handler = async (event, context) => {`,
+      ` const fn = await import("./${packagePosixPath}/index.mjs");`,
+      ` return fn.handler(event, context);`,
+      `};`,
+    ].join(""),
   );
 }
 


### PR DESCRIPTION
This PR fixes the issue described in this issue #340 

### Solution

By using the `import()` function the `process.env = ...` block runs first and the `CACHE_BUCKET_REGION` is defined.

### Tests

I've published it to a personal organization (https://www.npmjs.com/package/@sstlv/open-next) and tested it in my project, it's working properly.