### PR TITLE
Update bundle_size.mdx for excluding pdfjs-dist optional dependency docs

### DIFF
--- a/docs/pages/common_issues/bundle_size.mdx
+++ b/docs/pages/common_issues/bundle_size.mdx
@@ -33,7 +33,17 @@ eg: `--arch=arm64 --platform=linux --target=18 --libc=glibc`
 
 ##### pdfjs
 
-If you need to use pdfjs, you should install it with `npm i pdfjs-dist--no-optional` because the optional dep: `canvas` takes about 180MB.
+- If you need to use pdfjs, you should install it with `npm i pdfjs-dist--no-optional` because the optional dep: `canvas` takes about 180MB.
+
+- If the above dosn't work (or gives some compilation errors) you can try:
+
+```js
+  experimental: {
+    outputFileTracingExcludes: {
+      "*": ["node_modules/canvas"],
+    },
+  },
+```
 
 ##### Others
 

--- a/docs/pages/common_issues/bundle_size.mdx
+++ b/docs/pages/common_issues/bundle_size.mdx
@@ -35,7 +35,7 @@ eg: `--arch=arm64 --platform=linux --target=18 --libc=glibc`
 
 - If you need to use pdfjs, you should install it with `npm i pdfjs-dist--no-optional` because the optional dep: `canvas` takes about 180MB.
 
-- If the above dosn't work (or gives some compilation errors) you can try:
+- If the above doesn't work (or gives some compilation errors) you can try:
 
 ```js
   experimental: {


### PR DESCRIPTION
The current fix didn't work, but this updated fix did work for me. Hence proposing this as another solution.