### PR TITLE
fix(open-next): correctly set cache control for html pages

### DIFF
--- a/.changeset/wet-brooms-cheer.md
+++ b/.changeset/wet-brooms-cheer.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix(open-next): correctly set cache control for html pages

--- a/packages/open-next/src/adapters/plugins/routing/util.ts
+++ b/packages/open-next/src/adapters/plugins/routing/util.ts
@@ -74,7 +74,7 @@ export function fixCacheHeaderForHtmlPages(
   headers: Record<string, string | undefined>,
 ) {
   // WORKAROUND: `NextServer` does not set cache headers for HTML pages — https://github.com/serverless-stack/open-next#workaround-nextserver-does-not-set-cache-headers-for-html-pages
-  if (HtmlPages.includes(rawPath) && headers[CommonHeaders.CACHE_CONTROL]) {
+  if (HtmlPages.includes(rawPath)) {
     headers[CommonHeaders.CACHE_CONTROL] =
       "public, max-age=0, s-maxage=31536000, must-revalidate";
   }


### PR DESCRIPTION
As the code reads in the comment right above the line I changed, NextServer will not respond with a cache-control header value for HTML pages.

Since the cache-control header value is never set upstream, open-next also never set its own cache-control header due to this truthy if check.

As HTML pages never got any cache-control value set, what should be some of the fastest pre-rendered pages actually become slower than SSR/ISR pages that do get a cache header set correctly. (In the case of `cdk-nextjs`, the value actually gets falls back to `no-cache`)

I tested this locally with a number of CloudFront events against a site with static HTML as well as other SSG/ISR page types and it helped a lot for static HTML pages. 🚀