### PR TITLE
security fix: upgrade sharp version to 0.32.6

### DIFF
--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -367,7 +367,7 @@ function createImageOptimizationBundle() {
   // For SHARP_IGNORE_GLOBAL_LIBVIPS see: https://github.com/lovell/sharp/blob/main/docs/install.md#aws-lambda
 
   const nodeOutputPath = path.resolve(outputPath);
-  const sharpVersion = process.env.SHARP_VERSION ?? "0.32.6";
+  const sharpVersion = process.env.SHARP_VERSION ?? "0.33.2";
 
   //check if we are running in Windows environment then set env variables accordingly.
   try {

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -367,7 +367,7 @@ function createImageOptimizationBundle() {
   // For SHARP_IGNORE_GLOBAL_LIBVIPS see: https://github.com/lovell/sharp/blob/main/docs/install.md#aws-lambda
 
   const nodeOutputPath = path.resolve(outputPath);
-  const sharpVersion = process.env.SHARP_VERSION ?? "0.32.5";
+  const sharpVersion = process.env.SHARP_VERSION ?? "0.32.6";
 
   //check if we are running in Windows environment then set env variables accordingly.
   try {


### PR DESCRIPTION
AWS Security Hub throws a HIGH-level severity finding on the image optimization lambda resource regarding the version of `sharp`.

Installed version: 0.32.5
Fixed version: 0.32.6

[GHSA-54xq-cgqr-rpm3](https://github.com/advisories/GHSA-54xq-cgqr-rpm3)
[CVE-2023-4863 - sharp](https://nvd.nist.gov/vuln/detail/CVE-2023-4863)

This PR bumps the installed version of [sharp](https://www.npmjs.com/package/sharp) in the build step to the minimum fixed version `0.32.6`, but if desired we can upgrade to the latest version at the time of writing `0.33.2`