### PR TITLE
Fix cannot write default config file b/c folder not created

### DIFF
--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -11,6 +11,7 @@ import {
 } from "fs";
 import path from "path";
 import { NextConfig, PrerenderManifest } from "types/next-types";
+import logger from "../logger";
 
 export async function copyTracedFiles(
   buildOutputPath: string,
@@ -19,7 +20,7 @@ export async function copyTracedFiles(
   routes: string[],
   bundledNextServer: boolean,
 ) {
-  console.time("copyTracedFiles");
+  const tsStart = Date.now();
   const dotNextDir = path.join(buildOutputPath, ".next");
   const standaloneDir = path.join(dotNextDir, "standalone");
   const standaloneNextDir = path.join(standaloneDir, packagePath, ".next");
@@ -232,5 +233,5 @@ export async function copyTracedFiles(
     });
   }
 
-  console.timeEnd("copyTracedFiles");
+  logger.debug("copyTracedFiles:", Date.now() - tsStart, "ms");
 }

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -17,14 +17,17 @@ const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
 export type BuildOptions = ReturnType<typeof normalizeOptions>;
 
-export function normalizeOptions(opts: OpenNextConfig, root: string) {
-  const appPath = path.join(process.cwd(), opts.appPath || ".");
-  const buildOutputPath = path.join(process.cwd(), opts.buildOutputPath || ".");
+export function normalizeOptions(config: OpenNextConfig, root: string) {
+  const appPath = path.join(process.cwd(), config.appPath || ".");
+  const buildOutputPath = path.join(
+    process.cwd(),
+    config.buildOutputPath || ".",
+  );
   const outputDir = path.join(buildOutputPath, ".open-next");
 
   let nextPackageJsonPath: string;
-  if (opts.packageJsonPath) {
-    const _pkgPath = path.join(process.cwd(), opts.packageJsonPath);
+  if (config.packageJsonPath) {
+    const _pkgPath = path.join(process.cwd(), config.packageJsonPath);
     nextPackageJsonPath = _pkgPath.endsWith("package.json")
       ? _pkgPath
       : path.join(_pkgPath, "./package.json");
@@ -41,9 +44,6 @@ export function normalizeOptions(opts: OpenNextConfig, root: string) {
     outputDir,
     tempDir: path.join(outputDir, ".build"),
     debug: Boolean(process.env.OPEN_NEXT_DEBUG) ?? false,
-    buildCommand: opts.buildCommand,
-    dangerous: opts.dangerous,
-    externalMiddleware: opts.middleware?.external ?? false,
     monorepoRoot: root,
   };
 }


### PR DESCRIPTION
Happens when the `.open-next` folder does not exist.

Also includes a few trivial changes:
- Changed windows message to warning, since user can still continue
- Printing out a larger block of warning message and removed the 10s wait. Thinking being if it works for a windows user (miraculously), sucks having to wait 10s on each deploy.
- removed a few props from BuildOptions, that exists in both `config` and `options` that are being passed around.