### PR TITLE
[V3] chore: supports build method with custom config

### DIFF
--- a/packages/open-next/src/index.ts
+++ b/packages/open-next/src/index.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildSync } from "esbuild";
+import { OpenNextConfig } from "types/open-next.js";
+
 import { build } from "./build.js";
+import logger from "./logger.js";
 
 const command = process.argv[2];
 if (command !== "build") printHelp();
@@ -8,7 +15,13 @@ if (command !== "build") printHelp();
 const args = parseArgs();
 if (Object.keys(args).includes("--help")) printHelp();
 
-build(args["--config-path"]);
+// Load open-next.config.ts
+const tempDir = initTempDir();
+const openNextConfigPath = args["--config-path"];
+const configPath = compileOpenNextConfig(tempDir, openNextConfigPath);
+const buildConfig = (await import(configPath)).default as OpenNextConfig;
+
+build(buildConfig);
 
 function parseArgs() {
   return process.argv.slice(2).reduce(
@@ -39,4 +52,44 @@ function printHelp() {
   console.log("");
 
   process.exit(1);
+}
+
+function initTempDir() {
+  const dir = path.join(process.cwd(), ".open-next");
+  const tempDir = path.join(dir, ".build");
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(tempDir, { recursive: true });
+  return tempDir;
+}
+
+function compileOpenNextConfig(tempDir: string, openNextConfigPath?: string) {
+  const sourcePath = path.join(
+    process.cwd(),
+    openNextConfigPath ?? "open-next.config.ts",
+  );
+  const outputPath = path.join(tempDir, "open-next.config.mjs");
+
+  //Check if open-next.config.ts exists
+  if (!fs.existsSync(sourcePath)) {
+    //Create a simple open-next.config.mjs file
+    logger.debug("Cannot find open-next.config.ts. Using default config.");
+    fs.writeFileSync(
+      outputPath,
+      [
+        "var config = { default: { } };",
+        "var open_next_config_default = config;",
+        "export { open_next_config_default as default };",
+      ].join("\n"),
+    );
+  } else {
+    buildSync({
+      entryPoints: [sourcePath],
+      outfile: outputPath,
+      bundle: true,
+      format: "esm",
+      target: ["node18"],
+    });
+  }
+
+  return outputPath;
 }


### PR DESCRIPTION
Title: Enhance build method to accept custom configurations

Description:

- This pull request introduces the capability to invoke the build method with custom configurations, making it more flexible and generic. Previously, our implementation was limited to accepting only file paths as input. This enhancement allows for broader use cases.

Fixes:

- Resolved an issue where a TypeError: `Cannot read properties of undefined (reading 'buildCommand') `

Changes:

- Extended the build method to accept custom configurations in addition to file paths.