### PR TITLE
fix(open-next): parse cookies when converting response to cloudfront

### DIFF
--- a/.changeset/short-eels-compare.md
+++ b/.changeset/short-eels-compare.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix(open-next): parse cookies when converting response to cloudfront

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -218,6 +218,17 @@ function convertToCloudFrontRequestResult(
   Object.entries(result.headers)
     .filter(([key]) => key.toLowerCase() !== "content-length")
     .forEach(([key, value]) => {
+      if (key === "set-cookie") {
+        const cookies = parseCookies(value);
+        if (cookies) {
+          headers[key] = cookies.map((cookie) => ({
+            key,
+            value: cookie,
+          }));
+        }
+        return;
+      }
+
       headers[key] = [
         ...(headers[key] || []),
         ...(Array.isArray(value)

--- a/packages/tests-unit/tests/event-mapper.test.ts
+++ b/packages/tests-unit/tests/event-mapper.test.ts
@@ -1,0 +1,114 @@
+import { CloudFrontRequestResult } from "aws-lambda";
+
+import { convertTo } from "../../open-next/src/adapters/event-mapper";
+
+describe("convertTo", () => {
+  describe("CloudFront Result", () => {
+    it("Should parse the headers", () => {
+      const response = convertTo({
+        body: "",
+        headers: {
+          "content-type": "application/json",
+          test: "test",
+        },
+        isBase64Encoded: false,
+        statusCode: 200,
+        type: "cf",
+      }) as CloudFrontRequestResult;
+
+      expect(response?.headers).toStrictEqual({
+        "content-type": [
+          {
+            key: "content-type",
+            value: "application/json",
+          },
+        ],
+        test: [
+          {
+            key: "test",
+            value: "test",
+          },
+        ],
+      });
+    });
+
+    it("Should parse the headers with arrays", () => {
+      const response = convertTo({
+        body: "",
+        headers: {
+          test: ["test1", "test2"],
+        },
+        isBase64Encoded: false,
+        statusCode: 200,
+        type: "cf",
+      }) as CloudFrontRequestResult;
+
+      expect(response?.headers).toStrictEqual({
+        test: [
+          {
+            key: "test",
+            value: "test1",
+          },
+          {
+            key: "test",
+            value: "test2",
+          },
+        ],
+      });
+    });
+
+    it("Should parse the headers with cookies", () => {
+      const response = convertTo({
+        body: "",
+        headers: {
+          "set-cookie":
+            "test=1; Path=/; HttpOnly; Secure; SameSite=None, test=2; Path=/; HttpOnly; Secure; SameSite=None",
+        },
+        isBase64Encoded: false,
+        statusCode: 200,
+        type: "cf",
+      }) as CloudFrontRequestResult;
+
+      expect(response?.headers).toStrictEqual({
+        "set-cookie": [
+          {
+            key: "set-cookie",
+            value: "test=1; Path=/; HttpOnly; Secure; SameSite=None",
+          },
+          {
+            key: "set-cookie",
+            value: "test=2; Path=/; HttpOnly; Secure; SameSite=None",
+          },
+        ],
+      });
+    });
+
+    it("Should parse the headers with cookies + expires", () => {
+      const response = convertTo({
+        body: "",
+        headers: {
+          "set-cookie":
+            "test=1; Path=/; Expires=Sun, 14 Apr 2024 22:19:07 GMT; HttpOnly; Secure; SameSite=None, test=2; Path=/; Expires=Sun, 14 Apr 2024 22:19:07 GMT; HttpOnly; Secure; SameSite=None",
+        },
+        isBase64Encoded: false,
+        statusCode: 200,
+        type: "cf",
+      }) as CloudFrontRequestResult;
+
+      expect(response?.headers).toStrictEqual({
+        "set-cookie": [
+          {
+            key: "set-cookie",
+            value:
+              "test=1; Path=/; Expires=Sun, 14 Apr 2024 22:19:07 GMT; HttpOnly; Secure; SameSite=None",
+          },
+          {
+            key: "set-cookie",
+            value:
+              "test=2; Path=/; Expires=Sun, 14 Apr 2024 22:19:07 GMT; HttpOnly; Secure; SameSite=None",
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR parse the `set-cookie` header when converting the response to the CloudFront format.

#### Current Behavior

`set-cookie: test=1; Path=/; HttpOnly; Secure; SameSite=None, test=2; Path=/; HttpOnly; Secure; SameSite=None`

#### Expected Behavior

`set-cookie: test=1; Path=/; HttpOnly; Secure; SameSite=None`
`set-cookie: test=2; Path=/; HttpOnly; Secure; SameSite=None`

#### Tests

I've published it to my own npm org and tested it in my application:

https://www.npmjs.com/package/@sstlv/open-next/v/2.3.7-beta.0

#### Fixes

[#386]