### PR TITLE
fix(edge): remove read-only and blacklisted headers from cloudfront response

### DIFF
--- a/.changeset/small-knives-hug.md
+++ b/.changeset/small-knives-hug.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix(edge): remove read-only and blacklisted headers from cloudfront response

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -2,8 +2,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "name": "open-next",
-  "version": "2.3.8",
+  "name": "@sstlv/open-next",
+  "version": "2.3.8-beta-4",
   "bin": {
     "open-next": "./dist/index.js"
   },
@@ -56,6 +56,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sst/open-next.git"
+    "url": "git+https://github.com/lucasvieirasilva/open-next.git"
   }
 }

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -2,8 +2,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "name": "@sstlv/open-next",
-  "version": "2.3.8-beta-4",
+  "name": "open-next",
+  "version": "2.3.8",
   "bin": {
     "open-next": "./dist/index.js"
   },
@@ -56,6 +56,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lucasvieirasilva/open-next.git"
+    "url": "git+https://github.com/sst/open-next.git"
   }
 }

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -242,9 +242,9 @@ const CloudFrontBlacklistedHeaders = [
   "x-real-ip",
 
   // Read-only headers, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-read-only-headers
-  "cccept-Encoding",
+  "accept-encoding",
   "content-length",
-  "if-modified-Since",
+  "if-modified-since",
   "if-none-match",
   "if-range",
   "if-unmodified-since",
@@ -261,7 +261,6 @@ function convertToCloudFrontRequestResult(
   Object.entries(result.headers)
     .filter(
       ([key]) =>
-        key.toLowerCase() !== "content-length" &&
         !CloudFrontBlacklistedHeaders.some((header) =>
           typeof header === "string"
             ? header === key.toLowerCase()

--- a/packages/open-next/src/adapters/event-mapper.ts
+++ b/packages/open-next/src/adapters/event-mapper.ts
@@ -255,7 +255,7 @@ const CloudFrontBlacklistedHeaders = [
 function convertToCloudFrontRequestResult(
   result: InternalResult,
 ): CloudFrontRequestResult {
-  console.log("result headers", result.headers);
+  debug("result headers", result.headers);
 
   const headers: CloudFrontHeaders = {};
   Object.entries(result.headers)

--- a/packages/tests-unit/tests/event-mapper.test.ts
+++ b/packages/tests-unit/tests/event-mapper.test.ts
@@ -112,32 +112,60 @@ describe("convertTo", () => {
     });
 
     describe("blacklisted headers", () => {
-      it("should not include keep-alive header", () => {
+      it("should remove all blacklisted or read-only headers from the response", () => {
         const response = convertTo({
           body: "",
           headers: {
-            "keep-alive": "timeout=5",
+            Connection: "keep-alive",
+            expect: "100-continue",
+            "keep-Alive": "timeout=5, max=100",
+            "Proxy-Authenticate": "Basic",
+            "proxy-authorization": "Basic",
+            "proxy-connection": "keep-alive",
+            trailer: "Max-Forwards",
+            Upgrade: "HTTP/2.0",
+            "X-accel-buffering": "no",
+            "X-accel-charset": "UTF-8",
+            "x-accel-limit-rate": "1000",
+            "X-accel-redirect": "http://example.com",
+            "X-amz-cf-id": "example",
+            "x-amzn-auth": "example",
+            "x-Amzn-cf-billing": "example",
+            "x-Amzn-cf-id": "example",
+            "x-Amzn-Cf-xff": "example",
+            "x-amzn-Errortype": "example",
+            "x-amzn-fle-Profile": "example",
+            "x-amzn-header-Count": "example",
+            "x-amzn-Header-order": "example",
+            "X-Amzn-Lambda-Integration-tag": "example",
+            "x-amzn-Requestid": "example",
+            "x-edge-Location": "example",
+            "X-Cache": "Hit from cloudfront",
+            "X-Forwarded-proto": "https",
+            "x-Real-ip": "example",
+            "Accept-encoding": "gzip",
+            "content-length": "100",
+            "if-modified-Since": "example",
+            "if-none-match": "example",
+            "if-range": "example",
+            "if-unmodified-since": "example",
+            "transfer-encoding": "example",
+            via: "1.1 abc123.cloudfront.net (CloudFront)",
+            "x-powered-by": "Next.js",
           },
           isBase64Encoded: false,
           statusCode: 200,
           type: "cf",
         }) as CloudFrontRequestResult;
 
-        expect(response?.headers).toStrictEqual({});
-      });
-
-      it("should not include x-edge-* headers", () => {
-        const response = convertTo({
-          body: "",
-          headers: {
-            "x-edge-something": "something",
-          },
-          isBase64Encoded: false,
-          statusCode: 200,
-          type: "cf",
-        }) as CloudFrontRequestResult;
-
-        expect(response?.headers).toStrictEqual({});
+        expect(response?.headers).toStrictEqual({
+          "x-powered-by": [
+            {
+              key: "x-powered-by",
+              value: "Next.js",
+            },
+          ],
+        });
       });
     });
   });

--- a/packages/tests-unit/tests/event-mapper.test.ts
+++ b/packages/tests-unit/tests/event-mapper.test.ts
@@ -110,5 +110,35 @@ describe("convertTo", () => {
         ],
       });
     });
+
+    describe("blacklisted headers", () => {
+      it("should not include keep-alive header", () => {
+        const response = convertTo({
+          body: "",
+          headers: {
+            "keep-alive": "timeout=5",
+          },
+          isBase64Encoded: false,
+          statusCode: 200,
+          type: "cf",
+        }) as CloudFrontRequestResult;
+
+        expect(response?.headers).toStrictEqual({});
+      });
+
+      it("should not include x-edge-* headers", () => {
+        const response = convertTo({
+          body: "",
+          headers: {
+            "x-edge-something": "something",
+          },
+          isBase64Encoded: false,
+          statusCode: 200,
+          type: "cf",
+        }) as CloudFrontRequestResult;
+
+        expect(response?.headers).toStrictEqual({});
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR changes the CloudFront event mapper to remove blacklisted and read-only headers from the CloudFront response.

#### Reason

When a server action is called Next.js tries to set the Keep-alive header which it can't be provided in the CloudFront Lambda Edge.

That returns the following response

Status Code: 502

Response:

```log
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<HTML><HEAD><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
<TITLE>ERROR: The request could not be satisfied</TITLE>
</HEAD><BODY>
<H1>502 ERROR</H1>
<H2>The request could not be satisfied.</H2>
<HR noshade size="1px">
The Lambda function result failed validation: The function tried to add a blacklisted header.
We can't connect to the server for this app or website at this time. There might be too much traffic or a configuration error. Try again later, or contact the app or website owner.
<BR clear="all">
If you provide content to customers through CloudFront, you can find steps to troubleshoot and help prevent this error by reviewing the CloudFront documentation.
<BR clear="all">
<HR noshade size="1px">
<PRE>
Generated by cloudfront (CloudFront)
Request ID: gaOBxQLbSxm0GXcyaL7XMbBVwaAzyQpZ9XhoBm0i2ZBOWn9SZk303g==
</PRE>
<ADDRESS>
</ADDRESS>
</BODY></HTML>
```

#### Solution

There's an AWS document that lists all the blacklisted and read-only headers

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-headers

Based on this doc, I've changed the event-mapper to remove those headers from the response.

#### References

#392 