### PR TITLE
Fix incorrect 200 with wrong buildId

### DIFF
--- a/.changeset/blue-guests-punch.md
+++ b/.changeset/blue-guests-punch.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix incorrect 200 with wrong buildId for page router

--- a/packages/open-next/src/adapters/plugins/routing/default.replacement.ts
+++ b/packages/open-next/src/adapters/plugins/routing/default.replacement.ts
@@ -42,6 +42,11 @@ export const processInternalEvent: ProcessInternalEvent = async (
   const nextHeaders = addNextConfigHeaders(event, ConfigHeaders) ?? {};
 
   let internalEvent = fixDataPage(event, BuildId);
+  // If we return InternalResult, it means that the build id is not correct
+  // We should return a 404
+  if ("statusCode" in internalEvent) {
+    return internalEvent;
+  }
 
   internalEvent = handleFallbackFalse(internalEvent, PrerenderManifest);
 

--- a/packages/open-next/src/adapters/routing/matcher.ts
+++ b/packages/open-next/src/adapters/routing/matcher.ts
@@ -239,9 +239,24 @@ export function handleRedirects(
   }
 }
 
-export function fixDataPage(internalEvent: InternalEvent, buildId: string) {
+export function fixDataPage(
+  internalEvent: InternalEvent,
+  buildId: string,
+): InternalEvent | InternalResult {
   const { rawPath, query } = internalEvent;
   const dataPattern = `/_next/data/${buildId}`;
+  // Return 404 for data requests that don't match the buildId
+  if (rawPath.startsWith("/_next/data") && !rawPath.startsWith(dataPattern)) {
+    return {
+      type: internalEvent.type,
+      statusCode: 404,
+      body: "{}",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      isBase64Encoded: false,
+    };
+  }
 
   if (rawPath.startsWith(dataPattern) && rawPath.endsWith(".json")) {
     let newPath = rawPath.replace(dataPattern, "").replace(/\.json$/, "");


### PR DESCRIPTION
When requesting data for page dir with an incorrect `BUILD_ID`, we should return 404 with `{}` as the body.

This could cause some 500 on new deployment for page router, since running client could request data with the old `BUILD_ID`

Links to the discord thread : https://discord.com/channels/983865673656705025/1217895314741006387