### PR TITLE
Feat add a static etag for Image

### DIFF
--- a/.changeset/hot-toys-push.md
+++ b/.changeset/hot-toys-push.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Feat add a static etag for Image Optimization

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -375,11 +375,15 @@ async function createImageOptimizationBundle() {
     },
   });
 
-  // Copy over .next/required-server-files.json file
+  // Copy over .next/required-server-files.json file and BUILD_ID
   fs.mkdirSync(path.join(outputPath, ".next"));
   fs.copyFileSync(
     path.join(appBuildOutputPath, ".next/required-server-files.json"),
     path.join(outputPath, ".next/required-server-files.json"),
+  );
+  fs.copyFileSync(
+    path.join(appBuildOutputPath, ".next/BUILD_ID"),
+    path.join(outputPath, ".next/BUILD_ID"),
   );
 
   // Sharp provides pre-build binaries for all platforms. https://github.com/lovell/sharp/blob/main/docs/install.md#cross-platform


### PR DESCRIPTION
At the moment, image from `_next/image` are only cached in the cdn.
We don't generate any `ETag` either for the image so we never get 304.
Every stale request actually needs to be recomputed again.

In order to improve perf and reduce cost, this PR introduces an env variable `OPENNEXT_STATIC_ETAG` that we can set on the image opt function.
When you set this env variable, we create an `ETag` that depends on some parameter that we know before performing the image opt: ( href, width, quality, buildId )
Stale request will then return a 304 for request where `if-none-match` header is equal to the computed `ETag`

**One important things to note**, when using this env variable, it means that all the images should be considered immutable (The source image should not change) and the only way to change that is to change the `BUILD_ID` (on new deploy)

Not sure if this should be enabled by default or not. 