### PR TITLE
Fix next version check

### DIFF
--- a/.changeset/giant-pianos-float.md
+++ b/.changeset/giant-pianos-float.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix next version check

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -187,7 +187,7 @@ function setStandaloneBuildMode(monorepoRoot: string) {
 }
 
 function buildNextjsApp(packager: "npm" | "yarn" | "pnpm" | "bun") {
-  const { nextPackageJsonPath } = options;
+  const { appPackageJsonPath } = options;
   const command =
     config.buildCommand ??
     (["bun", "npm"].includes(packager)
@@ -195,7 +195,7 @@ function buildNextjsApp(packager: "npm" | "yarn" | "pnpm" | "bun") {
       : `${packager} build`);
   cp.execSync(command, {
     stdio: "inherit",
-    cwd: path.dirname(nextPackageJsonPath),
+    cwd: path.dirname(appPackageJsonPath),
   });
 }
 

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -213,19 +213,8 @@ function printHeader(header: string) {
 }
 
 function printNextjsVersion() {
-  const { appPath } = options;
-  cp.spawnSync(
-    "node",
-    [
-      "-e",
-      `"console.info('Next.js v' + require('next/package.json').version)"`,
-    ],
-    {
-      stdio: "inherit",
-      cwd: appPath,
-      shell: true,
-    },
-  );
+  const { nextVersion } = options;
+  logger.info(`Next.js version : ${nextVersion}`);
 }
 
 function printOpenNextVersion() {

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -25,19 +25,19 @@ export function normalizeOptions(config: OpenNextConfig, root: string) {
   );
   const outputDir = path.join(buildOutputPath, ".open-next");
 
-  let nextPackageJsonPath: string;
+  let appPackageJsonPath: string;
   if (config.packageJsonPath) {
     const _pkgPath = path.join(process.cwd(), config.packageJsonPath);
-    nextPackageJsonPath = _pkgPath.endsWith("package.json")
+    appPackageJsonPath = _pkgPath.endsWith("package.json")
       ? _pkgPath
       : path.join(_pkgPath, "./package.json");
   } else {
-    nextPackageJsonPath = findNextPackageJsonPath(appPath, root);
+    appPackageJsonPath = findNextPackageJsonPath(appPath, root);
   }
   return {
     openNextVersion: getOpenNextVersion(),
     nextVersion: getNextVersion(appPath),
-    nextPackageJsonPath,
+    appPackageJsonPath,
     appPath,
     appBuildOutputPath: buildOutputPath,
     appPublicPath: path.join(appPath, "public"),

--- a/packages/open-next/src/build/helper.ts
+++ b/packages/open-next/src/build/helper.ts
@@ -36,7 +36,7 @@ export function normalizeOptions(config: OpenNextConfig, root: string) {
   }
   return {
     openNextVersion: getOpenNextVersion(),
-    nextVersion: getNextVersion(nextPackageJsonPath),
+    nextVersion: getNextVersion(appPath),
     nextPackageJsonPath,
     appPath,
     appBuildOutputPath: buildOutputPath,
@@ -209,9 +209,12 @@ export function getOpenNextVersion(): string {
   return require(path.join(__dirname, "../../package.json")).version;
 }
 
-export function getNextVersion(nextPackageJsonPath: string): string {
-  const version = require(nextPackageJsonPath)?.dependencies?.next;
-  // require('next/package.json').version
+export function getNextVersion(appPath: string): string {
+  // We cannot just require("next/package.json") because it could be executed in a different directory
+  const nextPackageJsonPath = require.resolve("next/package.json", {
+    paths: [appPath],
+  });
+  const version = require(nextPackageJsonPath)?.version;
 
   if (!version) {
     throw new Error("Failed to find Next version");


### PR DESCRIPTION
Fix #406 
Instead of checking `package.json` for next version, we do a `require.resolve` in the appPath directory to find the `package.json` of next. Then we require this package and check for the version there.
This should work every time