### PR TITLE
Fix for external middleware

### DIFF
--- a/.changeset/warm-waves-allow.md
+++ b/.changeset/warm-waves-allow.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix for external middleware

--- a/packages/open-next/src/converters/aws-cloudfront.ts
+++ b/packages/open-next/src/converters/aws-cloudfront.ts
@@ -48,16 +48,6 @@ const CloudFrontBlacklistedHeaders = [
   "x-cache",
   "x-forwarded-proto",
   "x-real-ip",
-
-  // Read-only headers, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-read-only-headers
-  "accept-encoding",
-  "content-length",
-  "if-modified-since",
-  "if-none-match",
-  "if-range",
-  "if-unmodified-since",
-  "transfer-encoding",
-  "via",
 ];
 
 function normalizeCloudFrontRequestEventHeaders(


### PR DESCRIPTION
Fix a bug introduced in rc-13.
We should not remove read only headers https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-function-restrictions-all.html#function-restrictions-read-only-headers