### PR TITLE
Fix polyfill for crypto in the middleware 

### DIFF
--- a/.changeset/brave-games-argue.md
+++ b/.changeset/brave-games-argue.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix polyfill for crypto in the middleware 

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -3,7 +3,7 @@
     "access": "public"
   },
   "name": "open-next",
-  "version": "3.0.1",
+  "version": "3.0.1-middleware-fix",
   "bin": {
     "open-next": "./dist/index.js"
   },

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -99,10 +99,6 @@ globalThis._ROUTES = ${JSON.stringify(routes)};
 
 import {Buffer} from "node:buffer";
 globalThis.Buffer = Buffer;
-import crypto from "node:crypto";
-if(!globalThis.crypto){
-  globalThis.crypto = crypto;
-}
 
 import {AsyncLocalStorage} from "node:async_hooks";
 globalThis.AsyncLocalStorage = AsyncLocalStorage;
@@ -125,6 +121,26 @@ class OverrideRequest extends Request {
   }
 }
 globalThis.Request = OverrideRequest;
+
+// If we're not in cloudflare, we polyfill crypto
+// https://github.com/vercel/edge-runtime/blob/main/packages/primitives/src/primitives/crypto.js
+import { webcrypto } from 'node:crypto'
+if(!globalThis.crypto){
+  globalThis.crypto = new webcrypto.Crypto()
+}
+if(!globalThis.CryptoKey){
+  globalThis.CryptoKey = webcrypto.CryptoKey
+}
+function SubtleCrypto() {
+  if (!(this instanceof SubtleCrypto)) return new SubtleCrypto()
+  throw TypeError('Illegal constructor')
+}
+if(!globalThis.SubtleCrypto) {
+  globalThis.SubtleCrypto = SubtleCrypto
+}
+if(!globalThis.Crypto) {
+  globalThis.Crypto = webcrypto.Crypto
+}
 `
 }
 ${wasmFiles


### PR DESCRIPTION
Some libs depends on crypto function or class that are available globally in the edge runtime, but are not present by default in node, this should fix it