### PR TITLE
Add support for 'deno' server functions

### DIFF
--- a/.changeset/chilled-horses-drum.md
+++ b/.changeset/chilled-horses-drum.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Add support for 'deno' server functions

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -677,15 +677,16 @@ async function createCacheAssets(monorepoRoot: string) {
 /* Server Helper Functions */
 /***************************/
 
-function compileCache() {
-  const outfile = path.join(options.outputDir, ".build", "cache.cjs");
+export function compileCache(format: "cjs" | "esm" = "cjs") {
+  const ext = format === "cjs" ? "cjs" : "mjs";
+  const outfile = path.join(options.outputDir, ".build", `cache.${ext}`);
   esbuildSync(
     {
       external: ["next", "styled-jsx", "react", "@aws-sdk/*"],
       entryPoints: [path.join(__dirname, "adapters", "cache.js")],
       outfile,
       target: ["node18"],
-      format: "cjs",
+      format,
       banner: {
         js: [
           `globalThis.disableIncrementalCache = ${

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -188,7 +188,7 @@ export interface FunctionOptions extends DefaultFunctionOptions {
    * Runtime used
    * @default "node"
    */
-  runtime?: "node" | "edge";
+  runtime?: "node" | "edge" | "deno";
   /**
    * @default "regional"
    */


### PR DESCRIPTION
This patch adds support for running Open-next server functions with the [Deno lambda](https://github.com/denoland/deno-lambda) runtime layer.

Discussed briefly with @conico974 on Discord, adding `runtime: "deno"` made most sense.

## Changes

- Compile a ES module version of `cache.ts` when runtime is set to "deno"
- Add a `deno.json` and rename function entrypoint as `index.ts` (this will be redundant with Deno 2)
- Import node globals in the entrypoint

## Example

Here's how a deployment config would look like:
```typescript
// open-next.config.ts
export default {
  default: {
    runtime: "deno"
  }
}
```

```typescript
// sst.config.ts
export default $config({
  app(input) {
    return {
      name: "my-app",
      removal: input?.stage === "production" ? "retain" : "remove",
      home: "aws",
    };
  },
  async run() {
    new sst.aws.Nextjs("MyWeb", {
      transform: {
        server: {
          /* Amazon Linux 2023 */
          runtime: "provided.al2023",
          /* Deno lambda layer */
          layers: ["arn:aws:lambda:ap-south-1:381491846142:layer:deno:2"]
        }
      }
    });
  }
});
```

```
sst deploy
```

Next.js page: https://dvwb0nol21fnx.cloudfront.net 
API route: https://dvwb0nol21fnx.cloudfront.net/api/hello