### PR TITLE
Fix small typo

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -58,5 +58,5 @@ OpenNext aims to support all Next.js 13 features. Some features are work in prog
 ## Who is using OpenNext?
 
 [NHS England](https://github.com/nhs-england-tools/terraform-aws-opennext),
-[Udacity](https://engineering.udacity.com/deploying-next-js-on-the-edge-with-sst-is-sst-the-game-changer-its-claimed-to-be-1f05a0abc27c)
+[Udacity](https://engineering.udacity.com/deploying-next-js-on-the-edge-with-sst-is-sst-the-game-changer-its-claimed-to-be-1f05a0abc27c),
 [Gymshark UK](https://uk.gymshark.com)


### PR DESCRIPTION
Fix small typo in the "Who is using OpenNext?" section.