### PR TITLE
fix static 404 & 500 in page router

### DIFF
--- a/.changeset/curly-points-remember.md
+++ b/.changeset/curly-points-remember.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix static 404 and 500 in page router

--- a/packages/open-next/package.json
+++ b/packages/open-next/package.json
@@ -3,7 +3,7 @@
     "access": "public"
   },
   "name": "open-next",
-  "version": "3.0.1-middleware-fix",
+  "version": "3.0.1",
   "bin": {
     "open-next": "./dist/index.js"
   },

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -98,6 +98,13 @@ See the docs for more information on how to bundle edge runtime functions.
       filesToCopy.set(f, f.replace(standaloneDir, outputDir));
     });
 
+    if (!existsSync(path.join(standaloneNextDir, `${fullFilePath}`))) {
+      throw new Error(
+        `This error should only happen for static 404 and 500 page from page router. Report this if that's not the case.,
+        File ${fullFilePath} does not exist`,
+      );
+    }
+
     filesToCopy.set(
       path.join(standaloneNextDir, fullFilePath),
       path.join(outputNextDir, fullFilePath),


### PR DESCRIPTION
When using page router and static 404 and 500 ( i.e. no `getStaticProps` ) `open-next build` would fail because it cannot find the js file. 