### PR TITLE
fix 404 when no route match at all

### DIFF
--- a/.changeset/tame-pets-juggle.md
+++ b/.changeset/tame-pets-juggle.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix 404 when no route match at all

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -284,6 +284,12 @@ export function fixCacheHeaderForHtmlPages(
   rawPath: string,
   headers: OutgoingHttpHeaders,
 ) {
+  // We don't want to cache error pages
+  if (rawPath === "/404" || rawPath === "/500") {
+    headers[CommonHeaders.CACHE_CONTROL] =
+      "private, no-cache, no-store, max-age=0, must-revalidate";
+    return;
+  }
   // WORKAROUND: `NextServer` does not set cache headers for HTML pages — https://github.com/serverless-stack/open-next#workaround-nextserver-does-not-set-cache-headers-for-html-pages
   if (HtmlPages.includes(rawPath)) {
     headers[CommonHeaders.CACHE_CONTROL] =

--- a/packages/tests-e2e/tests/pagesRouter/404.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/404.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("should return 404 on a route not corresponding to any route", async ({
+  page,
+}) => {
+  const result = await page.goto("/not-existing/route");
+  expect(result).toBeDefined();
+  expect(result?.status()).toBe(404);
+  const headers = result?.headers();
+  expect(headers?.["cache-control"]).toBe(
+    "private, no-cache, no-store, max-age=0, must-revalidate",
+  );
+});


### PR DESCRIPTION
When a request does not match any route at all, instead of returning the 404 page it returns a 500.
I'm pretty sure it does not happen on every version of next as well, something new that they added at one point.
It's an error in the next request handler itself (it tries to pipe to undefined), they must have moved this logic in the server router.

I need to add some e2e test for this as well.