### PR TITLE
Fix for readonly headers lambda@edge

### DIFF
--- a/.changeset/flat-coats-train.md
+++ b/.changeset/flat-coats-train.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix for readonly headers lambda@edge


### PR DESCRIPTION
Fix #427 
This should fix the issue for lambda@edge deployed function.
We need to find a way to properly test this, maybe setting some proper unit test would be enough for most cases.
