### PR TITLE
Fix for incorrect filter logic when copying traced files

### DIFF
--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -156,11 +156,10 @@ See the docs for more information on how to bundle edge runtime functions.
   //Actually copy the files
   filesToCopy.forEach((to, from) => {
     if (
-      from.includes("node_modules") &&
       //TODO: we need to figure which packages we could safely remove
-      (from.includes("caniuse-lite") ||
+      from.includes(path.join("node_modules", "caniuse-lite")) ||
         // from.includes("jest-worker") || This ones seems necessary for next 12
-        from.includes("sharp"))
+        from.includes(path.join("node_modules", "sharp"))
     ) {
       return;
     }

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -158,8 +158,8 @@ See the docs for more information on how to bundle edge runtime functions.
     if (
       //TODO: we need to figure which packages we could safely remove
       from.includes(path.join("node_modules", "caniuse-lite")) ||
-        // from.includes("jest-worker") || This ones seems necessary for next 12
-        from.includes(path.join("node_modules", "sharp"))
+      // from.includes("jest-worker") || This ones seems necessary for next 12
+      from.includes(path.join("node_modules", "sharp"))
     ) {
       return;
     }


### PR DESCRIPTION
This fixes a bug that I encountered while deploying [this](https://github.com/andreia-oca/chatbot-ollama) application.

The problem is that the code uses a file from the `highlight.js` module called `csharp.js`. When I deploy the application built by open-next, I encounter the following error at runtime: `Cannot find module 'highlight.js/lib/languages/csharp'`.

I found that the reason for this error is an early return from `copyTracedFiles.ts`, which is falsely skipping the file `.next/standalone/node_modules/highlight.js/lib/languages/csharp.js`.

The solution that I propose is to skip if the path contains "node_modules/sharp" and "node_modules/canius-lite".