### PR TITLE
Fix for lambda streaming on empty body

### DIFF
--- a/examples/sst/stacks/AppRouter.ts
+++ b/examples/sst/stacks/AppRouter.ts
@@ -4,6 +4,9 @@ export function AppRouter({ stack }) {
   // We should probably switch to ion once it's ready
   const site = new OpenNextCdkReferenceImplementation(stack, "approuter", {
     path: "../app-router",
+    environment: {
+      OPEN_NEXT_FORCE_NON_EMPTY_RESPONSE: "true",
+    },
   });
   // const site = new NextjsSite(stack, "approuter", {
   //   path: "../app-router",

--- a/examples/sst/stacks/OpenNextReferenceImplementation.ts
+++ b/examples/sst/stacks/OpenNextReferenceImplementation.ts
@@ -110,6 +110,7 @@ interface OpenNextOutput {
 
 interface OpenNextCdkReferenceImplementationProps {
   path: string;
+  environment?: Record<string, string>;
 }
 
 export class OpenNextCdkReferenceImplementation extends Construct {
@@ -122,6 +123,8 @@ export class OpenNextCdkReferenceImplementation extends Construct {
   private staticCachePolicy: ICachePolicy;
   private serverCachePolicy: CachePolicy;
 
+  private customEnvironment: Record<string, string>;
+
   public distribution: Distribution;
 
   constructor(
@@ -130,6 +133,7 @@ export class OpenNextCdkReferenceImplementation extends Construct {
     props: OpenNextCdkReferenceImplementationProps,
   ) {
     super(scope, id);
+    this.customEnvironment = props.environment ?? {};
     this.openNextBasePath = path.join(process.cwd(), props.path);
     execSync("npm run openbuild", {
       cwd: path.join(process.cwd(), props.path),
@@ -312,6 +316,7 @@ export class OpenNextCdkReferenceImplementation extends Construct {
       // Those 2 are used only for image optimizer
       BUCKET_NAME: this.bucket.bucketName,
       BUCKET_KEY_PREFIX: "_assets",
+      ...this.customEnvironment,
     };
   }
 

--- a/packages/open-next/src/wrappers/aws-lambda-streaming.ts
+++ b/packages/open-next/src/wrappers/aws-lambda-streaming.ts
@@ -31,7 +31,6 @@ const handler: WrapperHandler = async (handler, converter) =>
       }
 
       const internalEvent = await converter.convertFrom(event);
-      let _hasWriten = false;
 
       //Handle compression
       const acceptEncoding =
@@ -89,13 +88,9 @@ const handler: WrapperHandler = async (handler, converter) =>
           return compressedStream ?? responseStream;
         },
         onWrite: () => {
-          _hasWriten = true;
+          // _hasWriten = true;
         },
-        onFinish: () => {
-          if (!_hasWriten) {
-            compressedStream?.end(new Uint8Array(8));
-          }
-        },
+        onFinish: () => {},
       };
 
       const response = await handler(internalEvent, streamCreator);


### PR DESCRIPTION
This PR add an env variable `OPEN_NEXT_FORCE_NON_EMPTY_RESPONSE`, when set to true it will force writing something to the stream.

This should only be used with lambda streaming **AND** if you have issues with the stream hanging on empty body response (i.e. HEAD request, redirect...)
You should avoid using this as much as you can, because it modifies the response you send ( It might break some very specific cases )

It is disabled by default.
