### PR TITLE
Fix some cache issue

### DIFF
--- a/.changeset/small-rivers-taste.md
+++ b/.changeset/small-rivers-taste.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix some cache issue

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -308,10 +308,11 @@ export default class S3Cache {
         );
       }
       debug("Finished setting cache");
-      detachedPromise.resolve();
     } catch (e) {
-      detachedPromise.reject(e);
       error("Failed to set cache", e);
+    } finally {
+      // We need to resolve the promise even if there was an error
+      detachedPromise.resolve();
     }
   }
 

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -144,7 +144,8 @@ export default class S3Cache {
         value: value,
       } as CacheHandlerValue;
     } catch (e) {
-      error("Failed to get fetch cache", e);
+      // We can usually ignore errors here as they are usually due to cache not being found
+      debug("Failed to get fetch cache", e);
       return null;
     }
   }
@@ -208,7 +209,9 @@ export default class S3Cache {
         return null;
       }
     } catch (e) {
-      error("Failed to get body cache", e);
+      // We can usually ignore errors here as they are usually due to cache not being found
+      debug("Failed to get body cache", e);
+      debug("typeof e", typeof e);
       return null;
     }
   }
@@ -221,82 +224,88 @@ export default class S3Cache {
     if (globalThis.disableIncrementalCache) {
       return;
     }
-    if (data?.kind === "ROUTE") {
-      const { body, status, headers } = data;
-      await globalThis.incrementalCache.set(
-        key,
-        {
-          type: "route",
-          body: body.toString(
-            isBinaryContentType(String(headers["content-type"]))
-              ? "base64"
-              : "utf8",
-          ),
-          meta: {
-            status,
-            headers,
-          },
-        },
-        false,
-      );
-    } else if (data?.kind === "PAGE") {
-      const { html, pageData } = data;
-      const isAppPath = typeof pageData === "string";
-      if (isAppPath) {
-        globalThis.incrementalCache.set(
+    try {
+      if (data?.kind === "ROUTE") {
+        const { body, status, headers } = data;
+        await globalThis.incrementalCache.set(
           key,
           {
-            type: "app",
-            html,
-            rsc: pageData,
+            type: "route",
+            body: body.toString(
+              isBinaryContentType(String(headers["content-type"]))
+                ? "base64"
+                : "utf8",
+            ),
+            meta: {
+              status,
+              headers,
+            },
           },
           false,
         );
-      } else {
-        globalThis.incrementalCache.set(
+      } else if (data?.kind === "PAGE") {
+        const { html, pageData } = data;
+        const isAppPath = typeof pageData === "string";
+        if (isAppPath) {
+          globalThis.incrementalCache.set(
+            key,
+            {
+              type: "app",
+              html,
+              rsc: pageData,
+            },
+            false,
+          );
+        } else {
+          globalThis.incrementalCache.set(
+            key,
+            {
+              type: "page",
+              html,
+              json: pageData,
+            },
+            false,
+          );
+        }
+      } else if (data?.kind === "FETCH") {
+        await globalThis.incrementalCache.set<true>(key, data, true);
+      } else if (data?.kind === "REDIRECT") {
+        await globalThis.incrementalCache.set(
           key,
           {
-            type: "page",
-            html,
-            json: pageData,
+            type: "redirect",
+            props: data.props,
           },
           false,
+        );
+      } else if (data === null || data === undefined) {
+        await globalThis.incrementalCache.delete(key);
+      }
+      // Write derivedTags to dynamodb
+      // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
+      const derivedTags: string[] =
+        data?.kind === "FETCH"
+          ? ctx?.tags ?? data?.data?.tags ?? [] // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
+          : data?.kind === "PAGE"
+          ? data.headers?.["x-next-cache-tags"]?.split(",") ?? []
+          : [];
+      debug("derivedTags", derivedTags);
+      // Get all tags stored in dynamodb for the given key
+      // If any of the derived tags are not stored in dynamodb for the given key, write them
+      const storedTags = await globalThis.tagCache.getByPath(key);
+      const tagsToWrite = derivedTags.filter(
+        (tag) => !storedTags.includes(tag),
+      );
+      if (tagsToWrite.length > 0) {
+        await globalThis.tagCache.writeTags(
+          tagsToWrite.map((tag) => ({
+            path: key,
+            tag: tag,
+          })),
         );
       }
-    } else if (data?.kind === "FETCH") {
-      await globalThis.incrementalCache.set<true>(key, data, true);
-    } else if (data?.kind === "REDIRECT") {
-      await globalThis.incrementalCache.set(
-        key,
-        {
-          type: "redirect",
-          props: data.props,
-        },
-        false,
-      );
-    } else if (data === null || data === undefined) {
-      await globalThis.incrementalCache.delete(key);
-    }
-    // Write derivedTags to dynamodb
-    // If we use an in house version of getDerivedTags in build we should use it here instead of next's one
-    const derivedTags: string[] =
-      data?.kind === "FETCH"
-        ? ctx?.tags ?? data?.data?.tags ?? [] // before version 14 next.js used data?.data?.tags so we keep it for backward compatibility
-        : data?.kind === "PAGE"
-        ? data.headers?.["x-next-cache-tags"]?.split(",") ?? []
-        : [];
-    debug("derivedTags", derivedTags);
-    // Get all tags stored in dynamodb for the given key
-    // If any of the derived tags are not stored in dynamodb for the given key, write them
-    const storedTags = await globalThis.tagCache.getByPath(key);
-    const tagsToWrite = derivedTags.filter((tag) => !storedTags.includes(tag));
-    if (tagsToWrite.length > 0) {
-      await globalThis.tagCache.writeTags(
-        tagsToWrite.map((tag) => ({
-          path: key,
-          tag: tag,
-        })),
-      );
+    } catch (e) {
+      error("Failed to set cache", e);
     }
   }
 
@@ -304,16 +313,20 @@ export default class S3Cache {
     if (globalThis.disableDynamoDBCache || globalThis.disableIncrementalCache) {
       return;
     }
-    debug("revalidateTag", tag);
-    // Find all keys with the given tag
-    const paths = await globalThis.tagCache.getByTag(tag);
-    debug("Items", paths);
-    // Update all keys with the given tag with revalidatedAt set to now
-    await globalThis.tagCache.writeTags(
-      paths?.map((path) => ({
-        path: path,
-        tag: tag,
-      })) ?? [],
-    );
+    try {
+      debug("revalidateTag", tag);
+      // Find all keys with the given tag
+      const paths = await globalThis.tagCache.getByTag(tag);
+      debug("Items", paths);
+      // Update all keys with the given tag with revalidatedAt set to now
+      await globalThis.tagCache.writeTags(
+        paths?.map((path) => ({
+          path: path,
+          tag: tag,
+        })) ?? [],
+      );
+    } catch (e) {
+      error("Failed to revalidate tag", e);
+    }
   }
 }

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -213,7 +213,6 @@ export default class S3Cache {
     } catch (e) {
       // We can usually ignore errors here as they are usually due to cache not being found
       debug("Failed to get body cache", e);
-      debug("typeof e", typeof e);
       return null;
     }
   }
@@ -229,7 +228,6 @@ export default class S3Cache {
     const detachedPromise = new DetachedPromise<void>();
     globalThis.__als.getStore()?.pendingPromises.push(detachedPromise);
     try {
-      debug("set cache", { key, data });
       if (data?.kind === "ROUTE") {
         const { body, status, headers } = data;
         await globalThis.incrementalCache.set(

--- a/packages/open-next/src/adapters/server-adapter.ts
+++ b/packages/open-next/src/adapters/server-adapter.ts
@@ -11,6 +11,12 @@ setNodeEnv();
 setBuildIdEnv();
 setNextjsServerWorkingDirectory();
 
+// Because next is messing with fetch, we have to make sure that we use an untouched version of fetch
+declare global {
+  var internalFetch: typeof fetch;
+}
+globalThis.internalFetch = fetch;
+
 /////////////
 // Handler //
 /////////////

--- a/packages/open-next/src/cache/tag/dynamodb-lite.ts
+++ b/packages/open-next/src/cache/tag/dynamodb-lite.ts
@@ -179,7 +179,7 @@ const tagCache: TagCache = {
       for (const paramsChunk of toInsert) {
         await Promise.all(
           paramsChunk.map(async (params) => {
-            const response = await awsClient.fetch(
+            const response = await awsFetch(
               `https://dynamodb.${CACHE_BUCKET_REGION}.amazonaws.com`,
               {
                 method: "POST",

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -1,6 +1,7 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 
 import type { OpenNextConfig } from "types/open-next";
+import { DetachedPromise } from "utils/promise";
 
 import { debug } from "../adapters/logger";
 import { generateUniqueId } from "../adapters/util";
@@ -20,7 +21,10 @@ declare global {
   var incrementalCache: IncrementalCache;
   var fnName: string | undefined;
   var serverId: string;
-  var __als: AsyncLocalStorage<string>;
+  var __als: AsyncLocalStorage<{
+    requestId: string;
+    pendingPromises: DetachedPromise<void>[];
+  }>;
 }
 
 export async function createMainHandler() {

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -6,6 +6,7 @@ import {
   StreamCreator,
 } from "http/index.js";
 import { InternalEvent, InternalResult } from "types/open-next";
+import { DetachedPromise } from "utils/promise";
 
 import { debug, error, warn } from "../adapters/logger";
 import { convertRes, createServerResponse, proxyRequest } from "./routing/util";
@@ -13,7 +14,10 @@ import routingHandler, { MiddlewareOutputEvent } from "./routingHandler";
 import { requestHandler, setNextjsPrebundledReact } from "./util";
 
 // This is used to identify requests in the cache
-globalThis.__als = new AsyncLocalStorage<string>();
+globalThis.__als = new AsyncLocalStorage<{
+  requestId: string;
+  pendingPromises: DetachedPromise<any>[];
+}>();
 
 export async function openNextHandler(
   internalEvent: InternalEvent,
@@ -81,37 +85,44 @@ export async function openNextHandler(
       remoteAddress: preprocessedEvent.remoteAddress,
     };
     const requestId = Math.random().toString(36);
-    const internalResult = await globalThis.__als.run(requestId, async () => {
-      const preprocessedResult = preprocessResult as MiddlewareOutputEvent;
-      const req = new IncomingMessage(reqProps);
-      const res = createServerResponse(
-        preprocessedEvent,
-        overwrittenResponseHeaders,
-        responseStreaming,
-      );
+    const pendingPromises: DetachedPromise<void>[] = [];
+    const internalResult = await globalThis.__als.run(
+      { requestId, pendingPromises },
+      async () => {
+        const preprocessedResult = preprocessResult as MiddlewareOutputEvent;
+        const req = new IncomingMessage(reqProps);
+        const res = createServerResponse(
+          preprocessedEvent,
+          overwrittenResponseHeaders,
+          responseStreaming,
+        );
 
-      await processRequest(
-        req,
-        res,
-        preprocessedEvent,
-        preprocessedResult.isExternalRewrite,
-      );
+        await processRequest(
+          req,
+          res,
+          preprocessedEvent,
+          preprocessedResult.isExternalRewrite,
+        );
 
-      const { statusCode, headers, isBase64Encoded, body } = convertRes(res);
+        const { statusCode, headers, isBase64Encoded, body } = convertRes(res);
 
-      const internalResult = {
-        type: internalEvent.type,
-        statusCode,
-        headers,
-        body,
-        isBase64Encoded,
-      };
+        const internalResult = {
+          type: internalEvent.type,
+          statusCode,
+          headers,
+          body,
+          isBase64Encoded,
+        };
 
-      // reset lastModified. We need to do this to avoid memory leaks
-      delete globalThis.lastModified[requestId];
+        // reset lastModified. We need to do this to avoid memory leaks
+        delete globalThis.lastModified[requestId];
 
-      return internalResult;
-    });
+        // Wait for all promises to resolve
+        await Promise.all(pendingPromises.map((p) => p.promise));
+
+        return internalResult;
+      },
+    );
     return internalResult;
   }
 }

--- a/packages/open-next/src/core/requestHandler.ts
+++ b/packages/open-next/src/core/requestHandler.ts
@@ -118,6 +118,8 @@ export async function openNextHandler(
         delete globalThis.lastModified[requestId];
 
         // Wait for all promises to resolve
+        // We are not catching errors here, because they are catched before
+        // This may need to change in the future
         await Promise.all(pendingPromises.map((p) => p.promise));
 
         return internalResult;

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -10,7 +10,7 @@ import { InternalEvent } from "types/open-next.js";
 import { DetachedPromise } from "utils/promise.js";
 
 import { isBinaryContentType } from "../../adapters/binary.js";
-import { debug, error } from "../../adapters/logger.js";
+import { debug, error, warn } from "../../adapters/logger.js";
 
 /**
  *
@@ -385,11 +385,11 @@ export async function revalidateIfRequired(
         MessageDeduplicationId: hash(`${rawPath}-${lastModified}-${etag}`),
         MessageGroupId: generateMessageGroupId(rawPath),
       });
-      detachedPromise.resolve();
     } catch (e) {
-      detachedPromise.reject(e);
-      debug(`Failed to revalidate stale page ${rawPath}`);
-      debug(e);
+      error(`Failed to revalidate stale page ${rawPath}`,e);
+    } finally {
+      // We don't care if it fails or not, we don't want to block the request
+      detachedPromise.resolve();
     }
   }
 }

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -10,7 +10,7 @@ import { InternalEvent } from "types/open-next.js";
 import { DetachedPromise } from "utils/promise.js";
 
 import { isBinaryContentType } from "../../adapters/binary.js";
-import { debug, error, warn } from "../../adapters/logger.js";
+import { debug, error } from "../../adapters/logger.js";
 
 /**
  *
@@ -386,7 +386,7 @@ export async function revalidateIfRequired(
         MessageGroupId: generateMessageGroupId(rawPath),
       });
     } catch (e) {
-      error(`Failed to revalidate stale page ${rawPath}`,e);
+      error(`Failed to revalidate stale page ${rawPath}`, e);
     } finally {
       // We don't care if it fails or not, we don't want to block the request
       detachedPromise.resolve();

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -7,6 +7,7 @@ import { OpenNextNodeResponse } from "http/openNextResponse.js";
 import { parseHeaders } from "http/util.js";
 import type { MiddlewareManifest } from "types/next-types";
 import { InternalEvent } from "types/open-next.js";
+import { DetachedPromise } from "utils/promise.js";
 
 import { isBinaryContentType } from "../../adapters/binary.js";
 import { debug, error } from "../../adapters/logger.js";
@@ -323,7 +324,7 @@ export function addOpenNextHeader(headers: OutgoingHttpHeaders) {
   headers["X-OpenNext"] = "1";
   if (globalThis.openNextDebug) {
     headers["X-OpenNext-Version"] = globalThis.openNextVersion;
-    headers["X-OpenNext-RequestId"] = globalThis.__als.getStore();
+    headers["X-OpenNext-RequestId"] = globalThis.__als.getStore()?.requestId;
   }
 }
 
@@ -355,6 +356,11 @@ export async function revalidateIfRequired(
         : internalMeta?._nextRewroteUrl
       : rawPath;
 
+    // We want to ensure that the revalidation is done in the background
+    // But we should still wait for the queue send to be successful
+    const detachedPromise = new DetachedPromise<void>();
+    globalThis.__als.getStore()?.pendingPromises.push(detachedPromise);
+
     // We need to pass etag to the revalidation queue to try to bypass the default 5 min deduplication window.
     // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
     // If you need to have a revalidation happen more frequently than 5 minutes,
@@ -363,7 +369,7 @@ export async function revalidateIfRequired(
     try {
       const hash = (str: string) =>
         crypto.createHash("md5").update(str).digest("hex");
-      const requestId = globalThis.__als.getStore() ?? "";
+      const requestId = globalThis.__als.getStore()?.requestId ?? "";
 
       const lastModified =
         globalThis.lastModified[requestId] > 0
@@ -379,7 +385,9 @@ export async function revalidateIfRequired(
         MessageDeduplicationId: hash(`${rawPath}-${lastModified}-${etag}`),
         MessageGroupId: generateMessageGroupId(rawPath),
       });
+      detachedPromise.resolve();
     } catch (e) {
+      detachedPromise.reject(e);
       debug(`Failed to revalidate stale page ${rawPath}`);
       debug(e);
     }
@@ -440,7 +448,7 @@ export function fixISRHeaders(headers: OutgoingHttpHeaders) {
       "private, no-cache, no-store, max-age=0, must-revalidate";
     return;
   }
-  const requestId = globalThis.__als.getStore() ?? "";
+  const requestId = globalThis.__als.getStore()?.requestId ?? "";
   const _lastModified = globalThis.lastModified[requestId] ?? 0;
   if (headers[CommonHeaders.NEXT_CACHE] === "HIT" && _lastModified > 0) {
     // calculate age

--- a/packages/open-next/src/utils/fetch.ts
+++ b/packages/open-next/src/utils/fetch.ts
@@ -8,10 +8,17 @@ export function customFetchClient(client: AwsClient) {
     signed.headers.forEach((value, key) => {
       headers[key] = value;
     });
-    return globalThis.internalFetch(signed.url, {
+    const response = await globalThis.internalFetch(signed.url, {
       method: signed.method,
       headers,
       body: init.body,
     });
+    /**
+     * Response body must be consumed to avoid socket error.
+     * This is necessary otherwise we get some error : SocketError: other side closed
+     * https://github.com/nodejs/undici/issues/583#issuecomment-855384858
+     */
+    const clonedResponse = response.clone();
+    return clonedResponse;
   };
 }

--- a/packages/open-next/src/utils/fetch.ts
+++ b/packages/open-next/src/utils/fetch.ts
@@ -8,14 +8,10 @@ export function customFetchClient(client: AwsClient) {
     signed.headers.forEach((value, key) => {
       headers[key] = value;
     });
-    return fetch(signed.url, {
+    return globalThis.internalFetch(signed.url, {
       method: signed.method,
       headers,
       body: init.body,
-      // @ts-expect-error
-      next: {
-        internal: true,
-      },
     });
   };
 }

--- a/packages/open-next/src/utils/promise.ts
+++ b/packages/open-next/src/utils/promise.ts
@@ -1,0 +1,27 @@
+/**
+ * A `Promise.withResolvers` implementation that exposes the `resolve` and
+ * `reject` functions on a `Promise`.
+ * Copied from next https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/detached-promise.ts
+ * @see https://tc39.es/proposal-promise-with-resolvers/
+ */
+export class DetachedPromise<T = any> {
+  public readonly resolve: (value: T | PromiseLike<T>) => void;
+  public readonly reject: (reason: any) => void;
+  public readonly promise: Promise<T>;
+
+  constructor() {
+    let resolve: (value: T | PromiseLike<T>) => void;
+    let reject: (reason: any) => void;
+
+    // Create the promise and assign the resolvers to the object.
+    this.promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    // We know that resolvers is defined because the Promise constructor runs
+    // synchronously.
+    this.resolve = resolve!;
+    this.reject = reject!;
+  }
+}


### PR DESCRIPTION
Latest releases introduced multiple *-lite that replaced aws-sdk with aws4fetch. This introduced some bug and uncover some underlying issues with the incremental cache itself.

This PR fixes : 
- S3 cache NoSuchKey error will now always be in debug
- For some reasons, fetch (even with `next:internal` and an authorization header) sometimes will still uses the fetch cache for aws4fetch call. There is now a `globalThis.internalFetch` that we can use that is set at start to normal fetch.
- A weird `SocketError: other side closed` can happen when not reading the body ( which was the case for some aws call )

And the BIG one: 

Cache set to S3 and sending to SQS were not properly awaited. Next itself doesn't seem to wait for cache set to be done before returning the response. 
This has been undetected because those call can achieve before the lambda returns (but no guarantee of that) and because subsequent call to the same lambda instance resumed the execution of those call. The sdk was able to handle restarting the request from scratch, or maybe failing silently in some cases, but aws4fetch wasn't able to handle this.
This could also make some ISR call fails for up to 5min, for example if a revalidation request succeed, but the S3 PutObject failed the queue would not accept anymore request for this failed one for the 5 min deduplication window.


To fix this we used some detached promise along with AsyncLocalStorage to await everything we need before returning the response. 
This does not cause trouble for streaming return time ( at least in my account ) because it does not touch the stream, and it seems that they wait for the end of the handler function to end the lambda. Of course given aws records with streaming this could change, but there is a way around by awaiting those detached promises inside the `_flush` method of the `OpenNextNodeResponse`.
This also means that we might have a way to handle `next/after` natively in lambda

