### PR TITLE
Implement missing methods from response object to fix the middleware issue in next 14.4.12 or lower.

### DIFF
--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -306,4 +306,23 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
     }
     callback();
   }
+
+  get sent() {
+    return this.finished || this.headersSent;
+  }
+
+  getHeaderValues(name: string): string[] | undefined {
+    const values = this.getHeader(name);
+
+    if (values === undefined) return undefined;
+
+    return (Array.isArray(values) ? values : [values]).map((value) =>
+      value.toString(),
+    );
+  }
+
+  send() {
+    const body = this.body;
+    this.end(body);
+  }
 }


### PR DESCRIPTION
This pull request fixes an issue where the middlewares were not functioning properly with the combination of versions specified below. Specifically, the "Middleware — redirect" functionality was failing to work as expected.

SST v2.43.2
Next.js version : 13.4.12
OpenNext v3.0.2

The error was the following:

```
TypeError: res.send is not a function
    at Object.fn (/var/task/node_modules/next/dist/server/next-server.js:1933:33)
    at async Router.execute (/var/task/node_modules/next/dist/server/router.js:315:32)
    at async NextNodeServer.runImpl (/var/task/node_modules/next/dist/server/base-server.js:624:29)
    at async NextNodeServer.handleRequestImpl (/var/task/node_modules/next/dist/server/base-server.js:549:20)
```

The implementation adds the missing methods used by next.