### PR TITLE
Pass __nextDataReq in the middleware query params if already present

### DIFF
--- a/packages/open-next/src/core/routing/middleware.ts
+++ b/packages/open-next/src/core/routing/middleware.ts
@@ -161,8 +161,16 @@ export async function handleMiddleware(
     } else {
       const rewriteUrlObject = new URL(rewriteUrl);
       newUrl = rewriteUrlObject.pathname;
-      //reset qs
-      middlewareQueryString = {};
+
+      // Reset the query params if the middleware is a rewrite
+      if (middlewareQueryString["__nextDataReq"]) {
+        middlewareQueryString = {
+          __nextDataReq: middlewareQueryString["__nextDataReq"],
+        };
+      } else {
+        middlewareQueryString = {};
+      }
+
       rewriteUrlObject.searchParams.forEach((v: string, k: string) => {
         middlewareQueryString[k] = v;
       });


### PR DESCRIPTION
I've noticed that the response returned by the _next/data/.../middleware-geolocation.json endpoint is an entire HTML page instead of a JSON containing the props. I've also deployed the same app on Vercel and it responds with a JSON.

After a discussion with @conico974 on Discord, we came up with this fix.