### PR TITLE
[windows] Specify the `file://` protocol when importing config on Windows

### DIFF
--- a/.changeset/witty-dots-film.md
+++ b/.changeset/witty-dots-film.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+[windows] Specify the `file://` protocol when importing config on Windows

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -50,11 +50,13 @@ export async function build(
 
   // Load open-next.config.ts
   const tempDir = initTempDir();
-  const configPath = compileOpenNextConfigNode(
+  let configPath = compileOpenNextConfigNode(
     tempDir,
     openNextConfigPath,
     nodeExternals,
   );
+  // On Windows, we need to use file:// protocol to load the config file using import()
+  if (process.platform === "win32") configPath = `file://${configPath}`;
   config = (await import(configPath)).default as OpenNextConfig;
   validateConfig(config);
 


### PR DESCRIPTION
On Windows, if the file protocol is not specified when using dynamic imports, the process exits with `ERR_UNSUPPORTED_ESM_URL_SCHEME` error.

Full error:
```
node:internal/modules/esm/load:236
    throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(parsed, schemes);
          ^

Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:236:11)
    at defaultLoad (node:internal/modules/esm/load:128:3)
    at ModuleLoader.load (node:internal/modules/esm/loader:409:13)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:56)
    at new ModuleJob (node:internal/modules/esm/module_job:65:26)
    at #createModuleJob (node:internal/modules/esm/loader:303:17)
    at ModuleLoader.getJobFromResolveResult (node:internal/modules/esm/loader:260:34)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:241:17)
    at async ModuleLoader.import (node:internal/modules/esm/loader:328:23) {
  code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME'
```
