### PR TITLE
[windows] Add Windows compatibility for the `resolve` ESBuild plugin

### DIFF
--- a/.changeset/popular-kids-beam.md
+++ b/.changeset/popular-kids-beam.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+[windows] Add Windows compatibility for the `resolve` ESBuild plugin

--- a/packages/open-next/src/plugins/resolve.ts
+++ b/packages/open-next/src/plugins/resolve.ts
@@ -44,7 +44,7 @@ export function openNextResolvePlugin({
     name: "opennext-resolve",
     setup(build) {
       logger.debug(`OpenNext Resolve plugin for ${fnName}`);
-      build.onLoad({ filter: /core\/resolve.js/g }, async (args) => {
+      build.onLoad({ filter: /core(\/|\\)resolve\.js/g }, async (args) => {
         let contents = readFileSync(args.path, "utf-8");
         //TODO: refactor this. Every override should be at the same place so we can generate this dynamically
         if (overrides?.wrapper) {


### PR DESCRIPTION
Previously, the separator for the filter regex was hardcoded to `/` (Unix separator).

Now, we're also taking account for the `\` (Windows separator) in the filter regex.