### PR TITLE
[windows] Add Windows compatibility for the `replacement` ESBuild plugin

### DIFF
--- a/.changeset/shy-cups-notice.md
+++ b/.changeset/shy-cups-notice.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+[windows] Add Windows compatibility for the `replacement` ESBuild plugin

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -333,7 +333,8 @@ async function createImageOptimizationBundle(config: OpenNextConfig) {
     plugins.push(
       openNextReplacementPlugin({
         name: "opennext-14.1.1-image-optimization",
-        target: /plugins\/image-optimization\/image-optimization\.js/g,
+        target:
+          /plugins(\/|\\)image-optimization(\/|\\)image-optimization\.js/g,
         replacements: [
           require.resolve(
             "./adapters/plugins/image-optimization/image-optimization.replacement.js",

--- a/packages/open-next/src/build/createServerBundle.ts
+++ b/packages/open-next/src/build/createServerBundle.ts
@@ -207,7 +207,7 @@ async function generateBundle(
   const plugins = [
     openNextReplacementPlugin({
       name: `requestHandlerOverride ${name}`,
-      target: /core\/requestHandler.js/g,
+      target: /core(\/|\\)requestHandler\.js/g,
       deletes: disableNextPrebundledReact ? ["applyNextjsPrebundledReact"] : [],
       replacements: disableRouting
         ? [
@@ -219,7 +219,7 @@ async function generateBundle(
     }),
     openNextReplacementPlugin({
       name: `utilOverride ${name}`,
-      target: /core\/util.js/g,
+      target: /core(\/|\\)util\.js/g,
       deletes: [
         ...(disableNextPrebundledReact ? ["requireHooks"] : []),
         ...(disableRouting ? ["trustHostHeader"] : []),


### PR DESCRIPTION
Previously, the separator for the filter regex was hardcoded to `/` (Unix separator).

Now, we're also taking account for the `\` (Windows separator) in the filter regex.