### PR TITLE
Fix issues with revalidateTag/revalidatePath

### DIFF
--- a/.changeset/gold-paws-laugh.md
+++ b/.changeset/gold-paws-laugh.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+Fix issues with revalidateTag/revalidatePath

--- a/examples/app-router/app/api/revalidate-path/route.ts
+++ b/examples/app-router/app/api/revalidate-path/route.ts
@@ -1,9 +1,9 @@
-import { revalidateTag } from "next/cache";
+import { revalidatePath } from "next/cache";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  revalidateTag("revalidate");
+  revalidatePath("/revalidate-path");
 
   return new Response("ok");
 }

--- a/examples/app-router/app/revalidate-path/page.tsx
+++ b/examples/app-router/app/revalidate-path/page.tsx
@@ -18,9 +18,9 @@ export default async function Page() {
   return (
     <div>
       <h1>Time in Paris</h1>
-      <p>{parisTime}</p>
+      <p>Paris: {parisTime}</p>
       <h1>Time in London</h1>
-      <p>{londonTime}</p>
+      <p>London: {londonTime}</p>
     </div>
   );
 }

--- a/examples/app-router/app/revalidate-path/page.tsx
+++ b/examples/app-router/app/revalidate-path/page.tsx
@@ -1,0 +1,26 @@
+export default async function Page() {
+  const timeInParis = await fetch(
+    "http://worldtimeapi.org/api/timezone/Europe/Paris",
+    {
+      next: {
+        tags: ["path"],
+      },
+    },
+  );
+  // This one doesn't have a tag
+  const timeInLondon = await fetch(
+    "http://worldtimeapi.org/api/timezone/Europe/London",
+  );
+  const timeInParisJson = await timeInParis.json();
+  const parisTime = timeInParisJson.datetime;
+  const timeInLondonJson = await timeInLondon.json();
+  const londonTime = timeInLondonJson.datetime;
+  return (
+    <div>
+      <h1>Time in Paris</h1>
+      <p>{parisTime}</p>
+      <h1>Time in London</h1>
+      <p>{londonTime}</p>
+    </div>
+  );
+}

--- a/examples/app-router/middleware.ts
+++ b/examples/app-router/middleware.ts
@@ -43,7 +43,10 @@ export function middleware(request: NextRequest) {
   }
 
   // It is so that cloudfront doesn't cache the response
-  if (path.startsWith("/revalidate-tag")) {
+  if (
+    path.startsWith("/revalidate-tag") ||
+    path.startsWith("/revalidate-path")
+  ) {
     responseHeaders.set(
       "cache-control",
       "private, no-cache, no-store, max-age=0, must-revalidate",

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -371,9 +371,7 @@ export default class S3Cache {
           for (const path of paths) {
             // We need to find all hard tags for a given path
             const _tags = await globalThis.tagCache.getByPath(path);
-            const hardTags = _tags
-              .map((t) => t.split("/").splice(1).join("/"))
-              .filter((t) => !t.startsWith("_N_T_/"));
+            const hardTags = _tags.filter((t) => !t.startsWith("_N_T_/"));
             // For every hard tag, we need to find all paths and revalidate them
             for (const hardTag of hardTags) {
               const _paths = await globalThis.tagCache.getByTag(hardTag);

--- a/packages/open-next/src/cache/tag/dynamodb-lite.ts
+++ b/packages/open-next/src/cache/tag/dynamodb-lite.ts
@@ -70,6 +70,7 @@ const tagCache: TagCache = {
 
       const tags = Items?.map((item: any) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
+      // We need to remove the buildId from the path
       return tags.map((tag: string) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
     } catch (e) {
       error("Failed to get tags by path", e);

--- a/packages/open-next/src/cache/tag/dynamodb-lite.ts
+++ b/packages/open-next/src/cache/tag/dynamodb-lite.ts
@@ -70,7 +70,7 @@ const tagCache: TagCache = {
 
       const tags = Items?.map((item: any) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
-      return tags;
+      return tags.map((tag: string) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
     } catch (e) {
       error("Failed to get tags by path", e);
       return [];

--- a/packages/open-next/src/cache/tag/dynamodb.ts
+++ b/packages/open-next/src/cache/tag/dynamodb.ts
@@ -59,7 +59,8 @@ const tagCache: TagCache = {
       );
       const tags = result.Items?.map((item) => item.tag.S ?? "") ?? [];
       debug("tags for path", path, tags);
-      return tags;
+      // We need to remove the buildId from the path
+      return tags.map((tag) => tag.replace(`${NEXT_BUILD_ID}/`, ""));
     } catch (e) {
       error("Failed to get tags by path", e);
       return [];

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -64,3 +64,28 @@ test("Revalidate tag", async ({ page, request }) => {
   response = await responsePromise;
   expect(response.headers()["x-nextjs-cache"]).toEqual("HIT");
 });
+
+test("Revalidate path", async ({ page, request }) => {
+  await page.goto("/revalidate-path");
+
+  let elLayout = page.getByText("Paris:");
+  const initialParis = await elLayout.textContent();
+
+  elLayout = page.getByText("London:");
+  const initialLondon = await elLayout.textContent();
+
+  // Send revalidate path request
+  const result = await request.get("/api/revalidate-path");
+  expect(result.status()).toEqual(200);
+  const text = await result.text();
+  expect(text).toEqual("ok");
+
+  await page.goto("/revalidate-path");
+  elLayout = page.getByText("Paris:");
+  const newParis = await elLayout.textContent();
+  expect(newParis).not.toEqual(initialParis);
+
+  elLayout = page.getByText("London:");
+  const newLondon = await elLayout.textContent();
+  expect(newLondon).not.toEqual(initialLondon);
+});


### PR DESCRIPTION
- Fix `revalidateTag` for next 15+
- Fix `revalidatePath` not clearing the fetch cache ( When doing a `revalidatePath('/whatever')`, all the `fetch` or `unstable_cache` inside this route would return the cached value instead of refetching )

There is a few things that we need to think about:
Right now the fetch cache in OpenNext works in a different way than in `next start` to take full advantage of DynamoDB.
In `next start` for every get to the incremental cache, they check for every tag used in this get ( and this include layout, page and fetch cache tags ), we only check given the path which entry in DDB is newer, and if so consider the cache entry stale.  This mean we can make one single optimized query to DDB instead of either multiple get or an expensive scan/query.
On the other hand the current DDB solution requires a lot more write than the default cache included in next ( They only write on `revalidateTag` )

I think in the future we should probably support the 2 type of cache ( The next cache could be easily implemented in SQL for example, and it's way better to do it that way in SQL than the DDB way ). Even in DDB, someone barely using on demand revalidation would benefit from a next type of cache.

The other thing is, we may want to allow the `revalidatePath` to not clear the fetch cache, this gives a lot more flexibility and would allow to invalidate only what's really needed ( But that's not how next works right now ). Not sure if that's something that people may want. We could introduce an env variable that if set would make it work like right now  ( it's still possible to clear the fetch cache individually using `revalidateTag` and some custom tag )
