### PR TITLE
fix middleware for next 15

### DIFF
--- a/.changeset/angry-fans-kick.md
+++ b/.changeset/angry-fans-kick.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix middleware for next 15

--- a/packages/open-next/src/build/edge/createEdgeBundle.ts
+++ b/packages/open-next/src/build/edge/createEdgeBundle.ts
@@ -89,6 +89,14 @@ export async function buildEdgeBundle({
   const require = (await import("node:module")).createRequire(import.meta.url);
   const __filename = (await import("node:url")).fileURLToPath(import.meta.url);
   const __dirname = (await import("node:path")).dirname(__filename);
+
+  const defaultDefineProperty = Object.defineProperty;
+  Object.defineProperty = function(o, p, a) {
+    if(p=== '__import_unsupported') {
+      return;
+    }
+    return defaultDefineProperty(o, p, a);
+  };
   `
   }
   ${additionalInject ?? ""}


### PR DESCRIPTION
Middleware in the latest canary version of next are crashing with this error `Cannot redefine property: __import_unsupported`.
This PR fix it