### PR TITLE
Feat external cache

### DIFF
--- a/.changeset/perfect-wasps-walk.md
+++ b/.changeset/perfect-wasps-walk.md
@@ -1,0 +1,5 @@
+---
+"open-next": minor
+---
+
+Add an optional external cache

--- a/examples/app-pages-router/open-next.config.ts
+++ b/examples/app-pages-router/open-next.config.ts
@@ -6,6 +6,9 @@ const config = {
       patterns: ["/api/*"],
     },
   },
+  dangerous: {
+    enableCacheInterception: true,
+  },
   buildCommand: "npx turbo build",
 };
 

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -752,6 +752,7 @@ async function createMiddleware() {
       ...commonMiddlewareOptions,
       overrides: config.middleware?.override,
       defaultConverter: "aws-cloudfront",
+      includeCache: config.dangerous?.enableCacheInterception,
     });
   } else {
     await buildEdgeBundle({

--- a/packages/open-next/src/cache/incremental/types.ts
+++ b/packages/open-next/src/cache/incremental/types.ts
@@ -31,9 +31,9 @@ export type WithLastModified<T> = {
   value?: T;
 };
 
-export type CacheValue<IsFetch extends boolean> = IsFetch extends true
+export type CacheValue<IsFetch extends boolean> = (IsFetch extends true
   ? S3FetchCache
-  : S3CachedFile;
+  : S3CachedFile) & { revalidate?: number | false };
 
 export type IncrementalCache = {
   get<IsFetch extends boolean = false>(

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -38,6 +38,7 @@ export async function createMainHandler() {
     : config.default;
 
   globalThis.serverId = generateUniqueId();
+  globalThis.openNextConfig = config;
 
   // Default queue
   globalThis.queue = await resolveQueue(thisFunction.override?.queue);

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { NextConfig, PrerenderManifest } from "config/index";
 import { InternalEvent, InternalResult } from "types/open-next";
+import { emptyReadableStream, toReadableStream } from "utils/stream";
 
 import { debug } from "../../adapters/logger";
 import { CacheValue } from "../../cache/incremental/types";
@@ -109,7 +110,7 @@ async function generateResult(
   return {
     type: "core",
     statusCode: 200,
-    body,
+    body: toReadableStream(body, false),
     isBase64Encoded: false,
     headers: {
       ...cacheControl,
@@ -180,7 +181,7 @@ export async function cacheInterceptor(
           return {
             type: "core",
             statusCode: cachedData.value.meta?.status ?? 307,
-            body: "",
+            body: emptyReadableStream(),
             headers: {
               ...((cachedData.value.meta?.headers as Record<string, string>) ??
                 {}),

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+
+import { PrerenderManifest } from "config/index";
+import { InternalEvent, InternalResult } from "types/open-next";
+
+import { debug } from "../../adapters/logger";
+import { CacheValue } from "../../cache/incremental/types";
+import { generateMessageGroupId } from "./util";
+
+const CACHE_ONE_YEAR = 60 * 60 * 24 * 365;
+const CACHE_ONE_MONTH = 60 * 60 * 24 * 30;
+
+async function computeCacheControl(
+  path: string,
+  body: string,
+  host: string,
+  revalidate?: number | false,
+  lastModified?: number,
+) {
+  let finalRevalidate = CACHE_ONE_YEAR;
+
+  const existingRoute = Object.entries(PrerenderManifest.routes).find(
+    (p) => p[0] === path,
+  )?.[1];
+  if (revalidate === undefined && existingRoute) {
+    finalRevalidate =
+      existingRoute.initialRevalidateSeconds === false
+        ? CACHE_ONE_YEAR
+        : existingRoute.initialRevalidateSeconds;
+    // eslint-disable-next-line sonarjs/elseif-without-else
+  } else if (revalidate !== undefined) {
+    finalRevalidate = revalidate === false ? CACHE_ONE_YEAR : revalidate;
+  }
+  // calculate age
+  const age = Math.round((Date.now() - (lastModified ?? 0)) / 1000);
+  const hash = (str: string) => createHash("md5").update(str).digest("hex");
+  const etag = hash(body);
+  if (revalidate === 0) {
+    // This one should never happen
+    return {
+      "cache-control":
+        "private, no-cache, no-store, max-age=0, must-revalidate",
+      "x-opennext-cache": "ERROR",
+      etag,
+    };
+  } else if (finalRevalidate !== CACHE_ONE_YEAR) {
+    const sMaxAge = Math.max(finalRevalidate - age, 1);
+    debug("sMaxAge", {
+      finalRevalidate,
+      age,
+      lastModified,
+      revalidate,
+    });
+    const isStale = sMaxAge === 1;
+    if (isStale) {
+      await globalThis.queue.send({
+        MessageBody: { host, url: path },
+        MessageDeduplicationId: hash(`${path}-${lastModified}-${etag}`),
+        MessageGroupId: generateMessageGroupId(path),
+      });
+    }
+    return {
+      "cache-control": `s-maxage=${sMaxAge}, stale-while-revalidate=${CACHE_ONE_MONTH}`,
+      "x-opennext-cache": isStale ? "STALE" : "HIT",
+      etag,
+    };
+  } else {
+    return {
+      "cache-control": `s-maxage=${CACHE_ONE_YEAR}, stale-while-revalidate=${CACHE_ONE_MONTH}`,
+      "x-opennext-cache": "HIT",
+      etag,
+    };
+  }
+}
+
+async function generateResult(
+  event: InternalEvent,
+  cachedValue: CacheValue<false>,
+  lastModified?: number,
+): Promise<InternalResult> {
+  debug("Returning result from experimental cache");
+  let body = "";
+  let type = "application/octet-stream";
+  let isDataRequest = false;
+  switch (cachedValue.type) {
+    case "app":
+      isDataRequest = Boolean(event.headers["rsc"]);
+      body = isDataRequest ? cachedValue.rsc : cachedValue.html;
+      type = isDataRequest ? "text/x-component" : "text/html; charset=utf-8";
+      break;
+    case "page":
+      isDataRequest = Boolean(event.query["__nextDataReq"]);
+      body = isDataRequest
+        ? JSON.stringify(cachedValue.json)
+        : cachedValue.html;
+      type = isDataRequest ? "application/json" : "text/html; charset=utf-8";
+      break;
+  }
+  const cacheControl = await computeCacheControl(
+    event.rawPath,
+    body,
+    event.headers["host"],
+    cachedValue.revalidate,
+    lastModified,
+  );
+  return {
+    type: "core",
+    statusCode: 200,
+    body,
+    isBase64Encoded: false,
+    headers: {
+      ...cacheControl,
+      "content-type": type,
+      ...cachedValue.meta?.headers,
+    },
+  };
+}
+
+export async function cacheInterceptor(
+  event: InternalEvent,
+): Promise<InternalEvent | InternalResult> {
+  if (
+    Boolean(event.headers["next-action"]) ||
+    Boolean(event.headers["x-prerender-revalidate"])
+  )
+    return event;
+  const isISR =
+    Object.keys(PrerenderManifest.routes).includes(event.rawPath) ||
+    Object.values(PrerenderManifest.dynamicRoutes).some((dr) =>
+      new RegExp(dr.routeRegex).test(event.rawPath),
+    );
+  if (isISR) {
+    try {
+      const cachedData = await globalThis.incrementalCache.get(event.rawPath);
+      const host = event.headers["host"];
+      switch (cachedData.value?.type) {
+        case "app":
+        case "page":
+          return generateResult(
+            event,
+            cachedData.value,
+            cachedData.lastModified,
+          );
+        case "redirect":
+          const cacheControl = await computeCacheControl(
+            event.rawPath,
+            "",
+            host,
+            cachedData.value.revalidate,
+            cachedData.lastModified,
+          );
+          return {
+            type: "core",
+            statusCode: cachedData.value.meta?.status ?? 307,
+            body: "",
+            headers: {
+              ...((cachedData.value.meta?.headers as Record<string, string>) ??
+                {}),
+              ...cacheControl,
+            },
+            isBase64Encoded: false,
+          };
+        default:
+          return event;
+      }
+    } catch (e) {
+      // In case of error we fallback to the server
+      return event;
+    }
+  }
+  return event;
+}

--- a/packages/open-next/src/core/routing/cacheInterceptor.ts
+++ b/packages/open-next/src/core/routing/cacheInterceptor.ts
@@ -136,14 +136,18 @@ export async function cacheInterceptor(
     localizedPath = "index";
   }
 
+  debug("Checking cache for", localizedPath, PrerenderManifest);
+
   const isISR =
     Object.keys(PrerenderManifest.routes).includes(localizedPath) ||
     Object.values(PrerenderManifest.dynamicRoutes).some((dr) =>
       new RegExp(dr.routeRegex).test(localizedPath),
     );
+  debug("isISR", isISR);
   if (isISR) {
     try {
       const cachedData = await globalThis.incrementalCache.get(localizedPath);
+      debug("cached data in interceptor", cachedData);
       if (cachedData.value?.type === "app") {
         // We need to check the tag cache now
         const _lastModified = await globalThis.tagCache.getLastModified(
@@ -188,6 +192,7 @@ export async function cacheInterceptor(
           return event;
       }
     } catch (e) {
+      debug("Error while fetching cache", e);
       // In case of error we fallback to the server
       return event;
     }

--- a/packages/open-next/src/core/routing/util.ts
+++ b/packages/open-next/src/core/routing/util.ts
@@ -393,7 +393,7 @@ export async function revalidateIfRequired(
 // We can't just use a random string because we need to ensure that the same rawPath
 // will always have the same messageGroupId.
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript#answer-47593316
-function generateMessageGroupId(rawPath: string) {
+export function generateMessageGroupId(rawPath: string) {
   let a = cyrb128(rawPath);
   // We use mulberry32 to generate a random int between 0 and MAX_REVALIDATE_CONCURRENCY
   var t = (a += 0x6d2b79f5);

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -55,12 +55,12 @@ const dynamicRegexp = RoutesManifest.routes.dynamic.map(
 function applyMiddlewareHeaders(
   eventHeaders: Record<string, string | string[]>,
   middlewareHeaders: Record<string, string | string[] | undefined>,
+  setPrefix = true,
 ) {
   Object.entries(middlewareHeaders).forEach(([key, value]) => {
     if (value) {
-      eventHeaders[`x-middleware-response-${key}`] = Array.isArray(value)
-        ? value.join(",")
-        : value;
+      eventHeaders[`${setPrefix ? "x-middleware-response-" : ""}${key}`] =
+        Array.isArray(value) ? value.join(",") : value;
     }
   });
 }
@@ -183,12 +183,17 @@ export default async function routingHandler(
     globalThis.openNextConfig.dangerous?.enableCacheInterception &&
     !("statusCode" in internalEvent)
   ) {
+    debug("Cache interception enabled");
     internalEvent = await cacheInterceptor(internalEvent);
     if ("statusCode" in internalEvent) {
-      applyMiddlewareHeaders(internalEvent.headers, {
-        ...middlewareResponseHeaders,
-        ...nextHeaders,
-      });
+      applyMiddlewareHeaders(
+        internalEvent.headers,
+        {
+          ...middlewareResponseHeaders,
+          ...nextHeaders,
+        },
+        false,
+      );
       return internalEvent;
     }
   }

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -7,6 +7,7 @@ import {
 import { InternalEvent, InternalResult, Origin } from "types/open-next";
 
 import { debug } from "../adapters/logger";
+import { cacheInterceptor } from "./routing/cacheInterceptor";
 import {
   addNextConfigHeaders,
   fixDataPage,
@@ -178,6 +179,13 @@ export default async function routingHandler(
         : value;
     }
   });
+
+  if (!("statusCode" in internalEvent)) {
+    internalEvent = await cacheInterceptor(internalEvent);
+    if ("statusCode" in internalEvent) {
+      return internalEvent;
+    }
+  }
 
   return {
     internalEvent,

--- a/packages/open-next/src/core/routingHandler.ts
+++ b/packages/open-next/src/core/routingHandler.ts
@@ -179,7 +179,10 @@ export default async function routingHandler(
     };
   }
 
-  if (!("statusCode" in internalEvent)) {
+  if (
+    globalThis.openNextConfig.dangerous?.enableCacheInterception &&
+    !("statusCode" in internalEvent)
+  ) {
     internalEvent = await cacheInterceptor(internalEvent);
     if ("statusCode" in internalEvent) {
       applyMiddlewareHeaders(internalEvent.headers, {

--- a/packages/open-next/src/plugins/edge.ts
+++ b/packages/open-next/src/plugins/edge.ts
@@ -194,6 +194,8 @@ ${contents}
   export const PrerenderManifest = ${JSON.stringify(PrerenderManifest)};
   export const AppPathsManifestKeys = ${JSON.stringify(AppPathsManifestKeys)};
   export const MiddlewareManifest = ${JSON.stringify(MiddlewareManifest)};
+
+  process.env.NEXT_BUILD_ID = BuildId;
   
           `;
         return {

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -150,7 +150,13 @@ export interface MiddlewareManifest {
 }
 
 export interface PrerenderManifest {
-  routes: Record<string, never>;
+  routes: Record<
+    string,
+    {
+      // TODO: add the rest when needed for PPR
+      initialRevalidateSeconds: number | false;
+    }
+  >;
   dynamicRoutes: {
     [route: string]: {
       routeRegex: string;

--- a/packages/open-next/src/types/next-types.ts
+++ b/packages/open-next/src/types/next-types.ts
@@ -67,7 +67,7 @@ export interface i18nConfig {
 }
 export interface NextConfig {
   basePath?: string;
-  trailingSlash?: string;
+  trailingSlash?: boolean;
   skipTrailingSlashRedirect?: boolean;
   i18n?: i18nConfig;
   experimental: {

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -262,6 +262,13 @@ export interface OpenNextConfig {
     external: true;
 
     /**
+     * The override options for the middleware.
+     * By default the lite override are used (.i.e. s3-lite, dynamodb-lite, sqs-lite)
+     * @default undefined
+     */
+    override?: OverrideOptions;
+
+    /**
      * Origin resolver is used to resolve the origin for internal rewrite.
      * By default, it uses the pattern-env origin resolver.
      * Pattern env uses pattern set in split function options and an env variable OPEN_NEXT_ORIGIN

--- a/packages/open-next/src/types/open-next.ts
+++ b/packages/open-next/src/types/open-next.ts
@@ -42,6 +42,13 @@ export interface DangerousOptions {
    * @default false
    */
   disableIncrementalCache?: boolean;
+  /**
+   * Enable the cache interception.
+   * Every request will go through the cache interceptor, if it is found in the cache, it will be returned without going through NextServer.
+   * Not every feature is covered by the cache interceptor and it should fallback to the NextServer if the cache is not found.
+   * @default false
+   */
+  enableCacheInterception?: boolean;
 }
 
 export type BaseOverride = {

--- a/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
+++ b/packages/tests-e2e/tests/appRouter/revalidateTag.test.ts
@@ -21,7 +21,9 @@ test("Revalidate tag", async ({ page, request }) => {
   let newTime;
 
   let response = await responsePromise;
-  const nextCacheHeader = response.headers()["x-nextjs-cache"];
+  const headers = response.headers();
+  const nextCacheHeader =
+    headers["x-nextjs-cache"] ?? headers["x-opennext-cache"];
   expect(nextCacheHeader).toMatch(/^(HIT|STALE)$/);
 
   // Send revalidate tag request
@@ -62,7 +64,10 @@ test("Revalidate tag", async ({ page, request }) => {
   await page.goto("/revalidate-tag/nested");
 
   response = await responsePromise;
-  expect(response.headers()["x-nextjs-cache"]).toEqual("HIT");
+  const headersNested = response.headers();
+  const nextCacheHeaderNested =
+    headersNested["x-nextjs-cache"] ?? headersNested["x-opennext-cache"];
+  expect(nextCacheHeaderNested).toEqual("HIT");
 });
 
 test("Revalidate path", async ({ page, request }) => {


### PR DESCRIPTION
This PR allow the ISR/SSG cache to resolve before reaching `NextServer`.
This has 2 big benefits: 
- It reduces cold start because we don't need to load the js for the route for ISR/SSG ( It could have a big impact for path that match multiple route )
- It allows the cache hit to happen directly inside the external middleware ( This will allow us to make PPR works as intended inside the CDN and not in the server as in standalone mode)
This one probably need to be a Minor release as it will require some changes to the IAC ( external middleware will need extra permissions )

It is still WIP : 
- [x] Make it work with external middleware
- [ ] ~~Maybe implement PPR here ??? (It might be better in a subsequent PR as this might require a lot of changes)~~

Some notes around PPR : 
We probably want next to settle on an implementation, because as of right now there is no way to do it outside of minimal mode.
There is a dirty solution for this, we could have 2 version of NextServer running inside the handler, one in minimalMode for PPR and the normal one for the rest.
Maybe they'll decide to allow this for anyone and not only on vercel. ( we just need to have acces to the `_next/resume` endpoints )