### PR TITLE
fix lambda streaming hanging after return

### DIFF
--- a/.changeset/lucky-ravens-teach.md
+++ b/.changeset/lucky-ravens-teach.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix lambda streaming hanging after return

--- a/packages/open-next/src/types/aws-lambda.ts
+++ b/packages/open-next/src/types/aws-lambda.ts
@@ -9,7 +9,7 @@ export interface ResponseStream extends Writable {
 type Handler = (
   event: APIGatewayProxyEventV2,
   responseStream: ResponseStream,
-  context?: Context,
+  context: Context,
 ) => Promise<any>;
 
 interface Metadata {

--- a/packages/open-next/src/wrappers/aws-lambda-streaming.ts
+++ b/packages/open-next/src/wrappers/aws-lambda-streaming.ts
@@ -23,7 +23,12 @@ function formatWarmerResponse(event: WarmerEvent) {
 
 const handler: WrapperHandler = async (handler, converter) =>
   awslambda.streamifyResponse(
-    async (event: AwsLambdaEvent, responseStream): Promise<AwsLambdaReturn> => {
+    async (
+      event: AwsLambdaEvent,
+      responseStream,
+      context,
+    ): Promise<AwsLambdaReturn> => {
+      context.callbackWaitsForEmptyEventLoop = false;
       if ("type" in event) {
         const result = await formatWarmerResponse(event);
         responseStream.end(Buffer.from(JSON.stringify(result)), "utf-8");


### PR DESCRIPTION
It looks like aws has made an update again to how the runtime works when using streaming.
Now even after `end()` has been called on the stream and the handler returned, the lambda keeps running in the background doing nothing until it timeout (and you'll be billed for the full duration)

This should fix it.