### PR TITLE
fix issue with fetch cache for new page

### DIFF
--- a/.changeset/tame-foxes-compete.md
+++ b/.changeset/tame-foxes-compete.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix issue with fetch cache for new page

--- a/packages/open-next/src/adapters/cache.ts
+++ b/packages/open-next/src/adapters/cache.ts
@@ -148,7 +148,7 @@ export default class S3Cache {
       if (value === undefined) return null;
 
       // For cases where we don't have tags, we need to ensure that the soft tags are not being revalidated
-      // We only need to check for the path as it should already contains all the tags
+      // We only need to check for the path as it should already contain all the tags
       if ((tags ?? []).length === 0) {
         // Then we need to find the path for the given key
         const path = softTags?.find(
@@ -336,7 +336,7 @@ export default class S3Cache {
             path: key,
             tag: tag,
             // In case the tags are not there we just need to create them
-            // but we don't want them to return frrom `getLastModified` as they are not stale
+            // but we don't want them to return from `getLastModified` as they are not stale
             revalidatedAt: 1,
           })),
         );

--- a/packages/open-next/src/build.ts
+++ b/packages/open-next/src/build.ts
@@ -600,7 +600,8 @@ async function createCacheAssets(monorepoRoot: string) {
                     path.relative(outputPath, filePath).replace(".meta", ""),
                   ),
                 },
-                revalidatedAt: { N: `${Date.now()}` },
+                // We don't care about the revalidation time here, we just need to make sure it's there
+                revalidatedAt: { N: "1" },
               });
             });
         }
@@ -632,7 +633,7 @@ async function createCacheAssets(monorepoRoot: string) {
                   path.relative(fetchCachePath, filepath),
                 ),
               },
-              revalidatedAt: { N: `${Date.now()}` },
+              revalidatedAt: { N: "1" },
             });
           });
         },


### PR DESCRIPTION
When creating new ISR page at runtime, inserted tags would make the fetch cache stale.
This will also fix cache miss when deploying using the same prebuilt data (i.e. not running `next build` again)
Fix #493