### PR TITLE
patch asyncStorage for ISR and fetch

### DIFF
--- a/.changeset/mighty-elephants-design.md
+++ b/.changeset/mighty-elephants-design.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+patch asyncStorage for ISR and fetch

--- a/packages/open-next/src/build/copyTracedFiles.ts
+++ b/packages/open-next/src/build/copyTracedFiles.ts
@@ -1,3 +1,5 @@
+import url from "node:url";
+
 import {
   copyFileSync,
   existsSync,
@@ -13,6 +15,14 @@ import path from "path";
 import { NextConfig, PrerenderManifest } from "types/next-types";
 
 import logger from "../logger.js";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+
+function copyPatchFile(outputDir: string) {
+  const patchFile = path.join(__dirname, "patch", "patchedAsyncStorage.js");
+  const outputPatchFile = path.join(outputDir, "patchedAsyncStorage.cjs");
+  copyFileSync(patchFile, outputPatchFile);
+}
 
 export async function copyTracedFiles(
   buildOutputPath: string,
@@ -204,6 +214,9 @@ See the docs for more information on how to bundle edge runtime functions.
       );
     }
   });
+
+  // Copy patch file
+  copyPatchFile(path.join(outputDir, packagePath));
 
   // TODO: Recompute all the files.
   // vercel doesn't seem to do it, but it seems wasteful to have all those files

--- a/packages/open-next/src/build/patch/patchedAsyncStorage.ts
+++ b/packages/open-next/src/build/patch/patchedAsyncStorage.ts
@@ -1,0 +1,19 @@
+//@ts-nocheck
+
+const asyncStorage = require("next/dist/client/components/static-generation-async-storage.external.original");
+
+const staticGenerationAsyncStorage = {
+  run: (store, cb, ...args) =>
+    asyncStorage.staticGenerationAsyncStorage.run(store, cb, ...args),
+  getStore: () => {
+    const store = asyncStorage.staticGenerationAsyncStorage.getStore();
+    if (store) {
+      store.isOnDemandRevalidate =
+        store.isOnDemandRevalidate &&
+        !globalThis.__als.getStore().isISRRevalidation;
+    }
+    return store;
+  },
+};
+
+exports.staticGenerationAsyncStorage = staticGenerationAsyncStorage;

--- a/packages/open-next/src/core/createMainHandler.ts
+++ b/packages/open-next/src/core/createMainHandler.ts
@@ -24,6 +24,7 @@ declare global {
   var __als: AsyncLocalStorage<{
     requestId: string;
     pendingPromiseRunner: DetachedPromiseRunner;
+    isISRRevalidation?: boolean;
   }>;
 }
 

--- a/packages/open-next/src/core/patchAsyncStorage.ts
+++ b/packages/open-next/src/core/patchAsyncStorage.ts
@@ -1,0 +1,39 @@
+const mod = require("module");
+
+const resolveFilename = mod._resolveFilename;
+
+export function patchAsyncStorage() {
+  mod._resolveFilename = function (
+    originalResolveFilename: typeof resolveFilename,
+    request: string,
+    parent: any,
+    isMain: boolean,
+    options: any,
+  ) {
+    if (
+      request.endsWith("static-generation-async-storage.external") ||
+      request.endsWith("static-generation-async-storage.external.js")
+    ) {
+      return require.resolve("./patchedAsyncStorage.cjs");
+    } else if (
+      request.endsWith("static-generation-async-storage.external.original")
+    ) {
+      return originalResolveFilename.call(
+        mod,
+        request.replace(".original", ".js"),
+        parent,
+        isMain,
+        options,
+      );
+    } else
+      return originalResolveFilename.call(
+        mod,
+        request,
+        parent,
+        isMain,
+        options,
+      );
+
+    // We use `bind` here to avoid referencing outside variables to create potential memory leaks.
+  }.bind(null, resolveFilename);
+}


### PR DESCRIPTION
ISR request are treated as On demand revalidation by Next, and it makes the fetch data cache not work as expected (the fetch cache is bypassed for every ISR revalidation request)
Should fix #493 

I'm not a very big fan of this solution but we either do that or patch some files in Next code itself and it's probably even worse. 