### PR TITLE
fix cookies improperly set on node

### DIFF
--- a/packages/open-next/src/http/openNextResponse.ts
+++ b/packages/open-next/src/http/openNextResponse.ts
@@ -176,10 +176,6 @@ export class OpenNextNodeResponse extends Transform implements ServerResponse {
       };
     }
     this.fixHeaders(this.headers);
-    if (this._cookies.length > 0) {
-      // For cookies we cannot do the same as for other headers
-      this.headers[SET_COOKIE_HEADER] = this._cookies;
-    }
 
     if (this.streamCreator) {
       this.responseStream = this.streamCreator?.writeHeaders({

--- a/packages/open-next/src/wrappers/aws-lambda-streaming.ts
+++ b/packages/open-next/src/wrappers/aws-lambda-streaming.ts
@@ -35,8 +35,6 @@ const handler: WrapperHandler = async (handler, converter) =>
         return;
       }
 
-      let headersWritten = false;
-
       const internalEvent = await converter.convertFrom(event);
 
       //Handle compression
@@ -84,14 +82,12 @@ const handler: WrapperHandler = async (handler, converter) =>
             "application/vnd.awslambda.http-integration-response",
           );
           _prelude.headers["content-encoding"] = contentEncoding;
-          // We need to remove the set-cookie header as otherwise it will be set twice, once with the cookies in the prelude, and a second time with the set-cookie headers
-          delete _prelude.headers["set-cookie"];
+
           const prelude = JSON.stringify(_prelude);
 
           responseStream.write(prelude);
 
           responseStream.write(new Uint8Array(8));
-          headersWritten = true;
 
           return compressedStream ?? responseStream;
         },

--- a/packages/open-next/src/wrappers/node.ts
+++ b/packages/open-next/src/wrappers/node.ts
@@ -10,6 +10,7 @@ const wrapper: WrapperHandler = async (handler, converter) => {
     const internalEvent = await converter.convertFrom(req);
     const _res: StreamCreator = {
       writeHeaders: (prelude) => {
+        res.setHeader("Set-Cookie", prelude.cookies);
         res.writeHead(prelude.statusCode, prelude.headers);
         res.uncork();
         return res;


### PR DESCRIPTION
When setting multiple cookies using the node wrapper it will fail. This should fix it