### PR TITLE
fix matcher not working with i18n

### DIFF
--- a/.changeset/fifty-clocks-report.md
+++ b/.changeset/fifty-clocks-report.md
@@ -1,0 +1,5 @@
+---
+"open-next": patch
+---
+
+fix middleware and headers matcher not working properly with i18n

--- a/examples/pages-router/next.config.js
+++ b/examples/pages-router/next.config.js
@@ -12,6 +12,17 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  headers: () => [
+    {
+      source: "/",
+      headers: [
+        {
+          key: "x-custom-header",
+          value: "my custom header value",
+        },
+      ],
+    },
+  ],
   rewrites: () => [
     { source: "/rewrite", destination: "/", locale: false },
     {

--- a/examples/pages-router/src/middleware.ts
+++ b/examples/pages-router/src/middleware.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  return NextResponse.next({
+    headers: {
+      "x-from-middleware": "true",
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/"],
+};

--- a/packages/open-next/src/core/routing/matcher.ts
+++ b/packages/open-next/src/core/routing/matcher.ts
@@ -144,14 +144,24 @@ export function addNextConfigHeaders(
 
   const requestHeaders: Record<string, string> = {};
 
-  for (const { headers, has, missing, regex, source } of configHeaders) {
+  const localizedRawPath = localizePath(event);
+
+  for (const {
+    headers,
+    has,
+    missing,
+    regex,
+    source,
+    locale,
+  } of configHeaders) {
+    const path = locale === false ? rawPath : localizedRawPath;
     if (
-      new RegExp(regex).test(rawPath) &&
+      new RegExp(regex).test(path) &&
       checkHas(matcher, has) &&
       checkHas(matcher, missing, true)
     ) {
       const fromSource = match(source);
-      const _match = fromSource(rawPath);
+      const _match = fromSource(path);
       headers.forEach((h) => {
         try {
           const key = convertMatch(_match, compile(h.key), h.key);

--- a/packages/tests-e2e/tests/pagesRouter/i18n.test.ts
+++ b/packages/tests-e2e/tests/pagesRouter/i18n.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+
+test("Next config headers with i18n", async ({ page }) => {
+  const responsePromise = page.waitForResponse((response) => {
+    return response.status() === 200;
+  });
+  await page.goto("/");
+
+  const response = await responsePromise;
+  // Response header should be set
+  const headers = response.headers();
+  // Headers from next.config.js should be set
+  expect(headers["x-custom-header"]).toEqual("my custom header value");
+
+  // Headers from middleware should be set
+  expect(headers["x-from-middleware"]).toEqual("true");
+});


### PR DESCRIPTION
This PR fix the matcher not working for the default locale in `headers` from `next.config` and the matcher from the middleware
Fix #516 